### PR TITLE
Add definition for connect and disconnect events

### DIFF
--- a/EXPLAINER.md
+++ b/EXPLAINER.md
@@ -1,6 +1,6 @@
 # Serial API Explainer
 
-This document is an explainer for the Serial API, a proposed specification for allowing a web page to communicate with a serial device.
+This document is an explainer for the [Serial API](http://wicg.github.io/serial/), a proposed specification for allowing a web page to communicate with a serial device.
 
 ## Motivation
 
@@ -31,43 +31,117 @@ Before a site can connect to a serial device it must request access. If a site o
 
 ```javascript
 const filter = {
-  vendorId: 0x2341 // Arduino SA
+  usbVendorId: 0x2341 // Arduino SA
 };
 
 try {
-  let port = await navigator.serial.requestPort({filters: [filter]});
+  const port = await navigator.serial.requestPort({filters: [filter]});
   // Continue connecting to |port|.
 } catch (e) {
   // Permission to access a device was denied implicitly or explicitly by the user.
 }
 ```
 
-With access to a `SerialPort` instance the site may now open a connection to the port.
+With access to a `SerialPort` instance the site may now open a connection to the port. Most parameters to `open()` are optional however the baud rate is required as there is no sensible default. You as the developer must know the rate at which your device expects to communicate.
 
 ```javascript
-await port.open();
+await port.open({ baudrate: /* pick your baud rate */ });
 ```
 
 At this point the `readable` and `writable` attributes are populated with a [`ReadableStream`](https://streams.spec.whatwg.org/#rs-class) and [`WritableStream`](https://streams.spec.whatwg.org/#ws-class) that can be used to receive data from and send data to the connected device.
 
-In this example we assume a device implementing a protocol inspired by the [Hayes command set](https://en.wikipedia.org/wiki/Hayes_command_set). Since commands are encoded in ASCII a [`TextEncoderStream`](https://encoding.spec.whatwg.org/#interface-textencoderstream) and [`TextDecoderStream`](https://encoding.spec.whatwg.org/#interface-textdecoderstream) are attached to the port's streams in order to translate the `Uint8Array`s used by the `SerialPort`'s streams into strings.
+In this example we assume a device implementing a protocol inspired by the [Hayes command set](https://en.wikipedia.org/wiki/Hayes_command_set). Since commands are encoded in ASCII a [`TextEncoder`](https://encoding.spec.whatwg.org/#interface-textencoder) and [`TextDecoder`](https://encoding.spec.whatwg.org/#interface-textdecoder) are used to translate the `Uint8Array`s used by the `SerialPort`'s streams to and from strings.
 
 ```javascript
-let encoder = new TextEncoderStream();
-encoder.readable.pipeTo(port.writable);
-let writer = encoder.writable.getWriter();
+const encoder = new TextEncoder();
+const writer = encoder.writable.getWriter();
+writer.write(encoder.encode("AT"));
+
+const decoder = new TextDecoder();
+const reader = port.readable.getReader();
+const { value, done } = await reader.read();
+console.log(decoder.decode(value));
+// Expected output: OK
+```
+
+The readable and writable streams must be unlocked before the port can be closed.
+
+```javascript
+writer.releaseLock();
+reader.releaseLock();
+await port.close();
+```
+
+Rather than reading a single chunk from the stream code will often read continuously using a loop like this,
+
+```javascript
+const reader = port.readable.getReader();
+while (true) {
+  const { value, done } = await reader.read();
+  if (done) {
+    // |reader| has been canceled.
+    break;
+  }
+  // Do something with |value|...
+}
+reader.releaseLock();
+```
+
+In this case `port.readable` will not be unlocked until the stream encounters an error, so how do you close the port? Calling `cancel()` on `reader` will cause the `Promise` returned by `read()` to resolve immediately with `{ value: undefined, done: true }`. This will cause the code above to break out of the loop and unlock the stream so that the port can be closed,
+
+```javascript
+await reader.cancel();
+await port.close();
+```
+
+A serial port may generate one of a number of non-fatal read errors for conditions such as buffer overflow, framing or parity errors. These are thrown as exceptions from the `read()` method and cause the `ReadableStream` to become errored. If the error is non-fatal then `port.readable` is immediately replaced by a new `ReadableStream` that picks up right after the error. To expand the example above to handle these errors another loop is added,
+
+```javascript
+while (port.readable) {
+  const reader = port.readable.getReader();
+  while (true) {
+    let value, done;
+    try {
+      ({ value, done } = await reader.read());
+    } catch (error) {
+      // Handle |error|...
+      break;
+    }
+    if (done) {
+      // |reader| has been canceled.
+      break;
+    }
+    // Do something with |value|...
+  }
+  reader.releaseLock();
+}
+```
+
+If a fatal error occurs, such as a USB device being removed, then `port.readable` will be set to `null`.
+
+Revisiting the earlier example, for a device that always produces ASCII text the explicit calls to `encode()` and `decode()` can be removed through the use of [`TransformStream`](https://streams.spec.whatwg.org/#ts)s. In this example `writer` comes from a [`TextEncoderStream`](https://encoding.spec.whatwg.org/#interface-textencoderstream) and `reader` comes from a [`TextDecoderStream`](https://encoding.spec.whatwg.org/#interface-textdecoderstream). The `pipeTo()` method is used to connect these transforms to the port.
+
+```javascript
+const encoder = new TextEncoderStream();
+const writableStreamClosed = encoder.readable.pipeTo(port.writable);
+const writer = encoder.writable.getWriter();
 writer.write("AT");
 
-let reader = port.readable.pipeThrough(new TextDecoderStream()).getReader();
-let { value, done } = await reader.read();
+const decoder = new TextDecoderStream();
+const readableStreamClosed = port.readable.pipeTo(decoder.writable);
+const reader = decoder.readable.getReader();
+const { value, done } = await reader.read();
 console.log(value);
 // Expected output: OK
 ```
 
-The readable and writable streams must be unlocked before the port can be closed. If they have been piped through a [`TransformStream`](https://streams.spec.whatwg.org/#ts) then those must be closed first.
+When piping through a transform stream closing the port becomes more complicated. Closing `reader` or `writer` will cause an error to propagate through the transform streams to the underlying port. However, this propagation doesn't happen immediately. The new `writableStreamClosed` and `readableStreamClosed` promises are required to detect when `port.readable` and `port.writable` have been unlocked. Since canceling `reader` causes the stream to be aborted the resulting error must be caught and ignored,
 
 ```javascript
-await Promise.all([ writer.close(), reader.cancel() ]);
+writer.close();
+await writableStreamClosed;
+reader.cancel();
+await readableStreamClosed.catch(reason => {});
 await port.close();
 ```
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 [Serial ports API](http://wicg.github.io/serial/) for the platform. 
 
+### Explainer
+
+Details about the API including example usage code snippets and its motivation, privacy, and security considerations are described in the [Explainer](./EXPLAINER.md).
+
 ### Code of conduct
 
 We are committed to providing a friendly, safe and welcoming environment for all. Please read and respect the [W3C Code of Ethics and Professional Conduct](https://www.w3.org/Consortium/cepc/).

--- a/index.html
+++ b/index.html
@@ -131,7 +131,7 @@ for use.
     Promise&lt;void> open(SerialOptions options);
     Promise&lt;void> setSignals(SerialOutputSignals signals);
     Promise&lt;SerialInputSignals> getSignals();
-    void close();
+    Promise&lt;void> close();
   };
   ```
 
@@ -155,13 +155,13 @@ for use.
 
   ### <dfn>close()</dfn> method
 
-  When invoked on a {{SerialPort}} |port:SerialPort| the {{close()}} method,
-  the user agent MUST perform the following steps,
+  When the {{SerialPort/close()}} method is invoked, the user agent MUST perform the
+  following steps:
 
   1. Let |cancelPromise:Promise| be the result of invoking
-    |port|.{{readable}}.<a data-cite="streams#rs-cancel">`cancel()`</a>.
+    {{SerialPort/readable}}.{{ReadableStream/cancel()}}</a>.
   1. Let |abortPromise:Promise| be the result of invoking
-    |port|.{{writable}}.<a data-cite="streams#ws-abort">`abort()`</a>.
+    {{SerialPort/writable}}.{{WritableStream/abort()}}</a>.
   1. Let |promise:Promise| be the result of
     [=getting a promise to wait for all=] with «|cancelPromise|, |abortPromise|».
   1. Return |promise|.

--- a/index.html
+++ b/index.html
@@ -159,7 +159,7 @@ for use.
     SerialPortInfo getInfo();
 
     Promise&lt;void> open(SerialOptions options);
-    Promise&lt;void> setSignals(SerialOutputSignals signals);
+    Promise&lt;void> setSignals(optional SerialOutputSignals signals = {});
     Promise&lt;SerialInputSignals> getSignals();
     Promise&lt;void> close();
   };

--- a/index.html
+++ b/index.html
@@ -80,9 +80,6 @@ for use.
   ## <dfn>Serial</dfn> interface
 
   ```webidl
-    dictionary SerialPortRequestOptions {
-    };
-
     [Exposed=(DedicatedWorker, Window), SecureContext]
     interface Serial : EventTarget {
       attribute EventHandler onconnect;
@@ -115,6 +112,39 @@ for use.
         was granted.
     1. [=Resolve=] |promise| with |port|.
 
+</section>
+
+<section data-dfn-for="SerialPortRequestOptions">
+  ## <dfn>SerialPortRequestOptions</dfn> dictionary
+
+  ```webidl
+    dictionary SerialPortRequestOptions {
+      sequence&lt;SerialPortFilter> filters;
+    };
+  ```
+
+  <dl>
+    <dt><dfn>filters</dfn> member</dt>
+    <dd>Filters for serial ports</dd>
+  </dl>
+</section>
+
+<section data-dfn-for="SerialPortFilter">
+  ## <dfn>SerialPortFilter</dfn> dictionary
+
+  ```webidl
+    dictionary SerialPortFilter {
+      unsigned short usbVendorId;
+      unsigned short usbProductId;
+    };
+  ```
+
+  <dl>
+    <dt><dfn>usbVendorId</dfn> member</dt>
+    <dd>USB Vendor ID</dd>
+    <dt><dfn>usbProductId</dfn> member</dt>
+    <dd>USB Product ID</dd>
+  </dl>
 </section>
 
 <section data-dfn-for="SerialPort">
@@ -274,7 +304,7 @@ for use.
     };
   ```
 
-  <dl data-dfn-for="SerialOptions">
+  <dl>
     <dt>
       <dfn>baudrate</dfn> member
     </dt>

--- a/index.html
+++ b/index.html
@@ -20,6 +20,7 @@ welcome.
 </section>
 
 ## Usage example
+
 This example shows how to request an Arduino device from the user and set it up
 for use.
 
@@ -34,67 +35,67 @@ const port = await navigator.serial.requestPort(requestOptions);
 
 // Open and begin reading.
 await port.open({ baudrate: 115200 });
-const reader = port.in.getReader();
+const reader = port.readable.getReader();
 while (true) {
-  const {done, data} = await reader.read();
+  const { value, done } = await reader.read();
   if (done) break;
-  console.log(data);
+  console.log(value);
 }
 </pre>
 
-## Dependencies
-The <dfn>`ReadableStream`</dfn> and <dfn>`WritableStream`</dfn> interfaces are
-defined in [[!STREAMS]].
-
-The <dfn>`Promise`</dfn> and <dfn>`DOMException`</dfn> interfaces are defined
-in [[!DOM]].
-
 <section data-dfn-for="Navigator" data-link-for="Navigator">
-<h2><dfn>Navigator</dfn> partial interface</h2>
+## <dfn>Navigator</dfn> partial interface
 <pre class="idl">
 [Exposed=Window, SecureContext]
 partial interface Navigator {
   [SameObject] readonly attribute Serial serial;
 };
 </pre>
-<section>
-<h2><dfn>serial</dfn> attribute</h2>
+
+## <dfn>serial</dfn> attribute
 
 When getting, the <a>serial</a> attribute always returns the same instance of
 the <a>Serial</a> object.
 </section>
-</section>
 
 <section data-dfn-for="WorkerNavigator" data-link-for="WorkerNavigator">
-<h2><dfn>WorkerNavigator</dfn> partial interface</h2>
+## <dfn>WorkerNavigator</dfn> partial interface
 <pre class="idl">
 [Exposed=DedicatedWorker, SecureContext]
 partial interface WorkerNavigator {
   [SameObject] readonly attribute Serial serial;
 };
 </pre>
-<section>
-<h2><dfn>serial</dfn> attribute</h2>
+
+## <dfn>serial</dfn> attribute
 
 When getting, the <a>serial</a> attribute always returns the same instance of
 the <a>Serial</a> object.
 </section>
-</section>
 
 <section data-dfn-for="Serial" data-link-for="Serial">
-<h2><dfn>Serial</dfn> interface</h2>
-<pre class="idl">
+## <dfn>Serial</dfn> interface
+<pre class="idl" data-cite="DOM HTML">
+dictionary SerialPortRequestOptions {
+};
+
 [Exposed=(DedicatedWorker,Window), SecureContext]
 interface Serial : EventTarget {
   attribute EventHandler onconnect;
   attribute EventHandler ondisconnect;
+
   Promise&lt;sequence&lt;SerialPort>> getPorts();
-  [Exposed=Window] Promise&lt;SerialPort> requestPort(SerialPortRequestOptions options);
+  [Exposed=Window] Promise&lt;SerialPort> requestPort(optional SerialPortRequestOptions options = {});
 };
 </pre>
 
-<section>
-<h2><dfn>requestPort()</dfn> method</h2>
+## <dfn>onconnect</dfn> attribute
+
+## <dfn>ondisconnect</dfn> attribute
+
+## <dfn>getPorts()</dfn> method
+
+## <dfn>requestPort()</dfn> method
 
 The <a>requestPort()</a> method requests access to a serial port of the user's
 choice (see <a>security considerations</a>).
@@ -102,7 +103,7 @@ choice (see <a>security considerations</a>).
 When the <a>requestPort()</a> method is invoked, the user agent MUST perform the
 following steps:
 
- 1. Let <var>promise</var> be a newly created <a>`Promise`</a>.
+ 1. Let <var>promise</var> be a newly created <a data-cite="webidl#promise">`Promise`</a>.
  1. Return <var>promise</var> and run the remaining steps asynchronously.
  1. Request access to a serial port (see <a>security considerations</a>):
    1. If the access request is rejected
@@ -113,36 +114,56 @@ following steps:
       was granted and <a data-cite="promises-guide#resolve-promise">resolve</a>
       <var>promise</var> with <var>port</var>.
 </section>
-</section>
 
 <section data-dfn-for="SerialPort" data-link-for="SerialPort">
 <h2><dfn>SerialPort</dfn> interface</h2>
 
-<pre class="idl">
+<pre class="idl" data-cite="STREAMS">
 [Exposed=(DedicatedWorker,Window), SecureContext]
 interface SerialPort {
-  Promise&lt;void> open(optional SerialOptions options);
-  readonly attribute ReadableStream in;
-  readonly attribute WritableStream out;
+  readonly attribute ReadableStream readable;
+  readonly attribute WritableStream writable;
+
   SerialPortInfo getInfo();
+
+  Promise&lt;void> open(SerialOptions options);
+  Promise&lt;void> setSignals(SerialOutputSignals signals);
+  Promise&lt;SerialInputSignals> getSignals();
+  void close();
 };
 </pre>
 
-<section>
-<h2><dfn>getInfo()</dfn> method</h2>
+## <dfn>readable</dfn> attribute
+
+## <dfn>writable</dfn> attribute
+
+## <dfn>getInfo()</dfn> method
 
 The <a>getInfo()</a> method provides a means to get metadata corresponding to a
 <a>SerialPort</a> object.
 
 When the <a>getInfo()</a> method is invoked, the user agent MUST perform the
 <a>steps for getting metadata of a serial port</a>.
-</section>
+
+## <dfn>open()</dfn> method
+
+## <dfn>setSignals()</dfn> method
+
+## <dfn>getSignals()</dfn> method
+
+## <dfn>close()</dfn> method
+
+When invoked on a {{SerialPort}} <var>port</var> the <a>close()</a> method
+returns the result of
+`Promise.all([port.readable.cancel(), port.writable.abort()])`.
+
 </section>
 
 <section data-dfn-for="SerialPortInfo" data-link-for="SerialPortInfo">
-<h2><dfn>SerialPortInfo</dfn> interface</h2>
+## <dfn>SerialPortInfo</dfn> interface
 <pre class="idl">
-interface SerialPortInfo{
+[Exposed=(DedicatedWorker,Window), SecureContext]
+interface SerialPortInfo {
   maplike&lt;DOMString, DOMString?>;
 };
 </pre>
@@ -232,18 +253,15 @@ port</var> are as follows. The steps always return an instance of
 </section>
 
 <section data-dfn-for="SerialOptions" data-link-for="SerialOptions">
-<h2><dfn>SerialOptions</dfn> dictionary</h2>
+## <dfn>SerialOptions</dfn> dictionary
 <pre class="idl">
   dictionary SerialOptions {
-    long baudrate = 9600;
+    required unsigned long baudrate;
     octet databits = 8;
     octet stopbits = 1;
     ParityType parity = "none";
-    long buffersize = 255;
+    unsigned long buffersize = 255;
     boolean rtscts = false;
-    boolean xon = false;
-    boolean xoff = false;
-    boolean xany = false;
   };
 </pre>
 <dl data-dfn-for="SerialOptions">
@@ -251,54 +269,50 @@ port</var> are as follows. The steps always return an instance of
     <dfn>baudrate</dfn> member
   </dt>
   <dd>
-    One of 115200, 57600, 38400, 19200, 9600, 4800, 2400, 1800, 1200,
-    600, 300, 200, 150, 134, 110, 75, or 50.
+    A positive, non-zero value indicating the baud rate at which serial
+    communication should be established.
   </dd>
   <dt>
     <dfn>databits</dfn> member
   </dt>
   <dd>
-    One of 8, 7, 6, or 5.
+    The number of data bits per frame. Either 7 or 8.
   </dd>
   <dt>
     <dfn>stopbits</dfn> member
   </dt>
   <dd>
-    One of 1 or 2.
+    The number of stop bits at the end of a frame. Either 1 or 2.
   </dd>
   <dt>
     <dfn>parity</dfn> member'
   </dt>
   <dd>
-    The parity type.
+    The parity mode.
   </dd>
   <dt>
     <dfn>buffersize</dfn> member
   </dt>
+  <dd>
+    A positive, non-zero value indicating the size of the read and write
+    buffers that should be created.
+  </dd>
   <dt>
     <dfn>rtscts</dfn> member
   </dt>
-  <dt>
-    <dfn>xon</dfn> member
-  </dt>
-  <dt>
-    <dfn>xoff</dfn> member
-  </dt>
-  <dt>
-    <dfn>xany</dfn> member
-  </dt>
+  <dd>
+    If set to <code>true</code> then hardware flow control will be enabled.
+  </dd>
 </dl>
 </section>
 
 <section data-dfn-for="ParityType" data-link-for="ParityType">
-<h2><dfn>ParityType</dfn> enum</h2>
+## <dfn>ParityType</dfn> enum
 <pre class="idl">
 enum ParityType {
   "none",
   "even",
-  "odd",
-  "mark",
-  "space"
+  "odd"
 };
 </pre>
 <dl data-dfn-for"ParityType">
@@ -310,13 +324,163 @@ enum ParityType {
 
   <dt><dfn>odd</dfn></dt>
   <dd>Data word plus parity bit has odd parity.</dd>
-
-  <dt><dfn>mark</dfn></dt>
-  <dd>Parity bit has a mark symbol (logical one).</dd>
-
-  <dt><dfn>space</dfn></dt>
-  <dd>Parity bit has a space symbol (logical zero).</dd>
 </dl>
+</section>
+
+<section data-dfn-for="SerialInputSignals" data-link-for="SerialInputSignals">
+## <dfn>SerialInputSignals</dfn> dictionary
+<pre class="idl">
+  dictionary SerialInputSignals {
+    required boolean dcd;
+    required boolean cts;
+    required boolean ri;
+    required boolean dsr;
+  };
+</pre>
+<dl data-dfn-for="SerialInputSignals">
+  <dt><dfn>dcd</dfn> member</dt>
+  <dd>Data Carrier Detect</dd>
+  <dt><dfn>cts</dfn> member</dt>
+  <dd>Clear To Send</dd>
+  <dt><dfn>ri</dfn> member</dt>
+  <dd>Ring Indicator</dd>
+  <dt><dfn>dsr</dfn> member</dt>
+  <dd>Data Set Ready</dd>
+</dl>
+</section>
+
+<section data-dfn-for="SerialOutputSignals" data-link-for="SerialOutputSignals">
+## <dfn>SerialOutputSignals</dfn> dictionary
+<pre class="idl">
+  dictionary SerialOutputSignals {
+    boolean dtr;
+    boolean rts;
+    boolean brk;
+  };
+</pre>
+<dl data-dfn-for="SerialOutputSignals">
+  <dt><dfn>dtr</dfn></dt>
+  <dd>Data Terminal Ready</dd>
+  <dt><dfn>rts</dfn></dt>
+  <dd>Request To Send</dd>
+  <dt><dfn>brk</dfn></dt>
+  <dd>Break</dd>
+</dl>
+</section>
+
+<section>
+## Serial port source abstract operations
+
+## <dfn>SerialPortSourcePullAlgorithm</dfn>(<var>port</var>, <var>controller</var>)
+
+1. Let <var>promise</var> be a newly created
+   <a data-cite="webidl#promise">`Promise`</a>.
+1. <a data-cite="html#in-parallel">In parallel</a>, run the following steps:
+   1. Let <var>desiredSize</var> be <var>controller</var>.
+      <a data-cite="streams#rs-default-controller-desired-size">`desiredSize`</a>.
+   1. Let <var>buffer</var> be a newly created
+      <a data-cite="webidl#idl-ArrayBuffer">`ArrayBuffer`</a> of
+      <var>desiredSize</var> bytes.
+   1. Invoke the operating system to read up to <var>desiredSize</var> bytes
+      from <var>port</var> into <var>buffer</var>.
+   1. If no errors were encountered run the following steps:
+      1. Let <var>bytesRead</var> be the number of bytes written to
+         <var>buffer</var>.
+      1. Let <var>chunk</var> be a newly created
+         <a data-cite="webidl#idl-Uint8Array">`Uint8Array`</a> over the slice of
+         <var>buffer</var> from `0` to <var>bytesRead</var>.
+      1. Invoke <var>controller</var>.
+         <a data-cite="streams#rs-default-controller-enqueue">`enqueue()`</a>
+         with <var>chunk</var>.
+   1. If a buffer overrun condition was encountered, invoke
+      <var>controller</var>.
+      <a data-cite="streams#rs-default-controller-error">`error()`</a> with a
+      <dfn>`BufferOverrunError`</dfn>.
+   1. If a break condition was encountered, invoke <var>controller</var>.
+      <a data-cite="streams#rs-default-controller-error">`error()`</a> with a
+      <dfn>`BreakError`</dfn>.
+   1. If a framing error was encountered, invoke <var>controller</var>.
+      <a data-cite="streams#rs-default-controller-error">`error()`</a> with a
+      <dfn>`FramingError`</dfn>.
+   1. If a parity error was encountered, invoke <var>controller</var>.
+      <a data-cite="streams#rs-default-controller-error">`error()`</a> with a
+      <dfn>`ParityError`</dfn>.
+   1. If an operating system error was encountered, invoke
+      <var>controller</var>.
+      <a data-cite="streams#rs-default-controller-error">`error()`</a> with an
+      <a data-cite="webidl#unknownerror">`UnknownError`</a>.
+   1. If <var>port</var> was disconnected, invoke <var>controller</var>.
+      <a data-cite="streams#rs-default-controller-error">`error()`</a> with a
+      <a data-cite="webidl#networkerror">`NetworkError`</a>.
+   1. Resolve <var>promise</var>.
+1. Return <var>promise</var>.
+
+## <dfn>SerialPortSourceCancelAlgorithm</dfn>(port)
+
+1. Let <var>promise</var> be a newly created
+   <a data-cite="webidl#promise">`Promise`</a>.
+1. <a data-cite="html#in-parallel">In parallel</a>, invoke the operating system
+   to discard the contents of all software and hardware receive buffers for
+   <var>port</var> and resolve <var>promise</var>.
+1. Return <var>promise</var>.
+
+<p class="note">
+[[STREAMS]] specifies that {{SerialPortSourceCancelAlgorithm}} will only be
+invoked after the <a data-cite="webidl#promise">`Promise`</a> returned by a
+previous invocation of {{SerialPortSourcePullAlgorithm}} (if any) has resolved.
+This blocks cancelation of the stream until the operating system has completed
+a read operation.
+</p>
+</section>
+
+<section>
+## Serial port sink abstract operations
+
+## <dfn>SerialPortSinkWriteAlgorithm</dfn>(<var>port</var>, <var>chunk</var>)
+
+1. Let <var>promise</var> be a newly created
+   <a data-cite="webidl#promise">`Promise`</a>.
+1. <a data-cite="html#in-parallel">In parallel</a>, run the following steps:
+   1. Invoke the operating system to write <var>chunk</var> to <var>port</var>.
+   1. If the chunk was successfully written resolve <var>promise</var>.
+   1. If an operating system error was encountered, reject <var>promise</var>
+      with an <a data-cite="webidl#unknownerror">`UnknownError`</a>.
+   1. If <var>port</var> was disconnected, reject <var>promise</var> with a
+      <a data-cite="webidl#networkerror">`NetworkError`</a>.
+1. Return <var>promise</var>.
+
+<p class="note">
+[[STREAMS]] specifies that {{SerialPortSinkWriteAlgorithm}} will only be invoked
+after the <a data-cite="webidl#promise">`Promise`</a> returned by a previous
+invocation of this algorithm has resolved. This prevents implementations from
+coalescing multiple chunks waiting in the
+<a data-cite="streams#ws-class">`WritableStream`'s</a> internal queue.
+</p>
+
+## <dfn>SerialPortSinkAbortAlgorithm</dfn>(<var>port</var>, <var>reason</var>)
+
+1. Let <var>promise</var> be a newly created
+   <a data-cite="webidl#promise">`Promise`</a>.
+1. <a data-cite="html#in-parallel">In parallel</a>, invoke the operating system
+   to discard the contents of all software and hardware transmit buffers for
+   <var>port</var> and resolve <var>promise</var>.
+1. Return <var>promise</var>.
+
+<p class="note">
+[[STREAMS]] specifies that {{SerialPortSinkAbortAlgorithm}} will only be invoked
+after the <a data-cite="webidl#promise">`Promise`</a> returned by a previous
+invokation of {{SerialPortSinkWriteAlgorithm}} (if any) has resolved. This
+prevents users of this specification from also discarding the contents of the
+<a data-cite="streams#ws-class">`WritableStream`'s</a> internal queue.
+</p>
+
+## <dfn>SerialPortSinkCloseAlgorithm</dfn>(<var>port</var>)
+
+1. Let <var>promise</var> be a newly created
+   <a data-cite="webidl#promise">`Promise`</a>.
+1. <a data-cite="html#in-parallel">In parallel</a>, invoke the operating system
+   to flush the contents of all software and hardware transmit buffers for
+   <var>port</var> and resolve <var>promise</var>.
 </section>
 
 ## Security considerations
@@ -338,7 +502,7 @@ It is also RECOMMENDED that user agents provide users with a means for the end-
 user to view which independently of any access request, and be given the
 ability to revoke individual or complete access to serial ports at any time
 either at the user agent level or per [origin](http://www.whatwg.org/specs/web-apps/current-work/#origin-0)
-[[!HTML]].
+[[HTML]].
 
 <section class="informative">
 ## Use cases and requirements

--- a/index.html
+++ b/index.html
@@ -4,19 +4,19 @@
 <script class='remove' src='https://www.w3.org/Tools/respec/respec-w3c-common' async></script>
 <script class='remove' src="respecConfig.js"></script>
 <link rel="stylesheet" href="styles/spec.css">
-
-<img alt="" width="100" height="100" id="speclogo" src="images/logo_serial.svg">
-
 <section id='abstract'>
 The <cite>Serial API</cite> provides a way for websites to read and write from
 a serial device through script. Such an API would bridge the web and the
 physical world, by allowing documents to communicate with devices such as
 microcontrollers, 3D printers, and other serial devices.
+  
+There is also a companion <a
+href="https://github.com/WICG/serial/blob/gh-pages/EXPLAINER.md">explainer</a> document.
 </section>
 
 <section id='sotd'>
-This is a work in progress. All [contributions](https://github.com/WICG/serial)
-welcome.
+  This is a work in progress. All [contributions](https://github.com/WICG/serial)
+  welcome.
 </section>
 
 ## Usage example
@@ -24,554 +24,529 @@ welcome.
 This example shows how to request an Arduino device from the user and set it up
 for use.
 
-<pre class="example highlight">
-const requestOptions = {
-  // Filter on devices with the Arduino USB vendor ID.
-  filters: [{ vendorId: 0x2341 }],
-};
-
-// Request an Arduino from the user.
-const port = await navigator.serial.requestPort(requestOptions);
-
-// Open and begin reading.
-await port.open({ baudrate: 115200 });
-const reader = port.readable.getReader();
-while (true) {
-  const { value, done } = await reader.read();
-  if (done) break;
-  console.log(value);
-}
-</pre>
-
-<section data-dfn-for="Navigator" data-link-for="Navigator">
-## <dfn>Navigator</dfn> partial interface
-<pre class="idl">
-[Exposed=Window, SecureContext]
-partial interface Navigator {
-  [SameObject] readonly attribute Serial serial;
-};
-</pre>
-
-## <dfn>serial</dfn> attribute
-
-When getting, the <a>serial</a> attribute always returns the same instance of
-the <a>Serial</a> object.
-</section>
-
-<section data-dfn-for="WorkerNavigator" data-link-for="WorkerNavigator">
-## <dfn>WorkerNavigator</dfn> partial interface
-<pre class="idl">
-[Exposed=DedicatedWorker, SecureContext]
-partial interface WorkerNavigator {
-  [SameObject] readonly attribute Serial serial;
-};
-</pre>
-
-## <dfn>serial</dfn> attribute
-
-When getting, the <a>serial</a> attribute always returns the same instance of
-the <a>Serial</a> object.
-</section>
-
-<section data-dfn-for="Serial" data-link-for="Serial">
-## <dfn>Serial</dfn> interface
-<pre class="idl">
-dictionary SerialPortRequestOptions {
-};
-
-[Exposed=(DedicatedWorker,Window), SecureContext]
-interface Serial : EventTarget {
-  attribute EventHandler onconnect;
-  attribute EventHandler ondisconnect;
-
-  Promise&lt;sequence&lt;SerialPort>> getPorts();
-  [Exposed=Window] Promise&lt;SerialPort> requestPort(optional SerialPortRequestOptions options = {});
-};
-</pre>
-
-## <dfn>onconnect</dfn> attribute
-
-## <dfn>ondisconnect</dfn> attribute
-
-## <dfn>getPorts()</dfn> method
-
-## <dfn>requestPort()</dfn> method
-
-The <a>requestPort()</a> method requests access to a serial port of the user's
-choice (see <a>security considerations</a>).
-
-When the <a>requestPort()</a> method is invoked, the user agent MUST perform the
-following steps:
-
-1. Let |promise:Promise| be [=a new promise=].
-1. Return |promise| and run the remaining steps asynchronously.
-1. Request access to a serial port (see <a>security considerations</a>):
-   1. If the access request is rejected [=reject=] |promise| with {{AbortError}}
-      and terminate this algorithm.
-   1. Otherwise, let |port:SerialPort| be the {{SerialPort}} for which access
-      was granted and [=resolve=] |promise| with |port|.
-</section>
-
-<section data-dfn-for="SerialPort" data-link-for="SerialPort">
-<h2><dfn>SerialPort</dfn> interface</h2>
-
-<pre class="idl">
-[Exposed=(DedicatedWorker,Window), SecureContext]
-interface SerialPort {
-  readonly attribute ReadableStream readable;
-  readonly attribute WritableStream writable;
-
-  SerialPortInfo getInfo();
-
-  Promise&lt;void> open(SerialOptions options);
-  Promise&lt;void> setSignals(SerialOutputSignals signals);
-  Promise&lt;SerialInputSignals> getSignals();
-  void close();
-};
-</pre>
-
-## <dfn>readable</dfn> attribute
-
-## <dfn>writable</dfn> attribute
-
-## <dfn>getInfo()</dfn> method
-
-The <a>getInfo()</a> method provides a means to get metadata corresponding to a
-<a>SerialPort</a> object.
-
-When the <a>getInfo()</a> method is invoked, the user agent MUST perform the
-<a>steps for getting metadata of a serial port</a>.
-
-## <dfn>open()</dfn> method
-
-## <dfn>setSignals()</dfn> method
-
-## <dfn>getSignals()</dfn> method
-
-## <dfn>close()</dfn> method
-
-
-
-When invoked on a {{SerialPort}} |port:SerialPort| the {{close()}} method,
-the user agent MUST perform the following steps,
-
-1. Let |cancelPromise:Promise| be the result of invoking
-   |port|.{{readable}}.<a data-cite="streams#rs-cancel">`cancel()`</a>.
-1. Let |abortPromise:Promise| be the result of invoking
-   |port|.{{writable}}.<a data-cite="streams#ws-abort">`abort()`</a>.
-1. Let |promise:Promise| be the result of
-   [=getting a promise to wait for all=] with «|cancelPromise|, |abortPromise|».
-1. Return |promise|.
-
-</section>
-
-<section data-dfn-for="SerialPortInfo" data-link-for="SerialPortInfo">
-## <dfn>SerialPortInfo</dfn> interface
-<pre class="idl">
-[Exposed=(DedicatedWorker,Window), SecureContext]
-interface SerialPortInfo {
-  maplike&lt;DOMString, DOMString?>;
-};
-</pre>
-
-## Serial port metadata
-
-The value of certain attributes is dependent on the method that the system used
-to establish the serial port (e.g., USB), and so might not always be available.
-
-### Recommended serial port metadata
-
-When available, it is RECOMMENDED that user agents populate a `SerialPortInfo`
-object with the following information. If the value of piece of metadata is
-unavailable(e.g., if the manufacturer is unknown), then it is RECOMMNEDED that
-that metadata be excluded from the `SerialPortInfo`. For interoperability,
-user agents SHOULD use the values provided in they "Key" column of the
-<a>table of recommended metadata</a>.
-
-<table border="1">
-  <caption><dfn>Table of recommended metadata</dfn></caption>
-  <tr>
-    <th>Name</th>
-    <th>Key</th>
-    <th>Description</th>
-  </tr>
-  <tr>
-    <td>Serial Number</td>
-    <td>`serialNumber`</td>
-    <td></td>
-  </tr>
-  <tr>
-    <td>Manufacturer</td>
-    <td>`manufacturer`</td>
-    <td></td>
-  </tr>
-  <tr>
-    <td>Location ID</td>
-    <td>`locationId`</td>
-    <td></td>
-  </tr>
-  <tr>
-    <td>Vendor ID</td>
-    <td>`vendorId`</td>
-    <td></td>
-  </tr>
-  <tr>
-    <td>Vendor</td>
-    <td>`vendor`</td>
-    <td></td>
-  </tr>
-  <tr>
-    <td>Product ID</td>
-    <td>`productId`</td>
-    <td></td>
-  </tr>
-  <tr>
-    <td>Product</td>
-    <td>`product`</td>
-    <td></td>
-  </tr>
-</table>
-
-
-### Getting serial port metadata
-
-The <dfn>steps for getting metadata of a serial port</dfn> for a |serial
-port| are as follows. The steps always return an instance of
-`SerialPortInfo`, which contains the related metadata.
-
- 1. Let |info| be an object that implements the `SerialPortInfo`
-    interface.
- 1. Let |path| be a `DOMString` that represents the path of the
-    |serial port|.
- 1. Invoke |info|'s `set()` method using the string `"path"` as the
-    key, and |path| as the value.
- 1. For each additional metadata item known about the |serial port|,
-    perform the following sub-steps. Please see the <a>table of recommended
-    metadata</a> for a list of recommended metadata items that SHOULD be
-    included.
-    1. Let |key| be a `DOMString` for the commonly used name for this
-       key.
-    1. Let |value| be a `DOMString` for the commonly used name for
-       this key, or `null` otherwise.
-    1. Invoke |info|'s `set()` method using the string "path" as the
-       key, and |path| as the value.
- 1. Return |info|.
-</section>
-
-<section data-dfn-for="SerialOptions" data-link-for="SerialOptions">
-## <dfn>SerialOptions</dfn> dictionary
-<pre class="idl">
-  dictionary SerialOptions {
-    required unsigned long baudrate;
-    octet databits = 8;
-    octet stopbits = 1;
-    ParityType parity = "none";
-    unsigned long buffersize = 255;
-    boolean rtscts = false;
+<pre class="example js" title="Requesting an Arduino device">
+  const requestOptions = {
+    // Filter on devices with the Arduino USB vendor ID.
+    filters: [{ usbVendorId: 0x2341 }],
   };
+
+  // Request an Arduino from the user.
+  const port = await navigator.serial.requestPort(requestOptions);
+
+  // Open and begin reading.
+  await port.open({ baudrate: 115200 });
+  const reader = port.readable.getReader();
+
+  for await (const { value, done } of reader.read()) {
+    if (done) break;
+    console.log(value);
+  }
 </pre>
-<dl data-dfn-for="SerialOptions">
-  <dt>
-    <dfn>baudrate</dfn> member
-  </dt>
-  <dd>
-    A positive, non-zero value indicating the baud rate at which serial
-    communication should be established.
-  </dd>
-  <dt>
-    <dfn>databits</dfn> member
-  </dt>
-  <dd>
-    The number of data bits per frame. Either 7 or 8.
-  </dd>
-  <dt>
-    <dfn>stopbits</dfn> member
-  </dt>
-  <dd>
-    The number of stop bits at the end of a frame. Either 1 or 2.
-  </dd>
-  <dt>
-    <dfn>parity</dfn> member'
-  </dt>
-  <dd>
-    The parity mode.
-  </dd>
-  <dt>
-    <dfn>buffersize</dfn> member
-  </dt>
-  <dd>
-    A positive, non-zero value indicating the size of the read and write
-    buffers that should be created.
-  </dd>
-  <dt>
-    <dfn>rtscts</dfn> member
-  </dt>
-  <dd>
-    If set to <code>true</code> then hardware flow control will be enabled.
-  </dd>
-</dl>
+
+<section data-dfn-for="Navigator">
+  ## Extensions to the `Navigator` interface
+
+  ```webidl
+    [Exposed=Window, SecureContext]
+    partial interface Navigator {
+      [SameObject] readonly attribute Serial serial;
+    };
+  ```
+
+  ### <dfn>serial</dfn> attribute
+
+  When getting, the {{Navigator/serial}} attribute always returns the same instance of
+  the {{Serial}} object.
+
 </section>
 
-<section data-dfn-for="ParityType" data-link-for="ParityType">
-## <dfn>ParityType</dfn> enum
-<pre class="idl">
-enum ParityType {
-  "none",
-  "even",
-  "odd"
-};
-</pre>
-<dl data-dfn-for"ParityType">
-  <dt><dfn>none</dfn></dt>
-  <dd>No parity bit is sent for each data word.</dd>
+<section data-dfn-for="WorkerNavigator">
+  ## Extensions to `WorkerNavigator` interface
 
-  <dt><dfn>even</dfn></dt>
-  <dd>Data word plus parity bit has even parity.</dd>
+  ```webidl
+    [Exposed=DedicatedWorker, SecureContext]
+    partial interface WorkerNavigator {
+      [SameObject] readonly attribute Serial serial;
+    };
+  ```
 
-  <dt><dfn>odd</dfn></dt>
-  <dd>Data word plus parity bit has odd parity.</dd>
-</dl>
+  ### <dfn>serial</dfn> attribute</h2>
+
+  When getting, the {{WorkerNavigator/serial}} attribute always returns the same instance of
+  the {{Serial}} object.
 </section>
 
-<section data-dfn-for="SerialInputSignals" data-link-for="SerialInputSignals">
-## <dfn>SerialInputSignals</dfn> dictionary
-<pre class="idl">
+<section data-dfn-for="Serial">
+  ## <dfn>Serial</dfn> interface
+
+  ```webidl
+    dictionary SerialPortRequestOptions {
+    };
+
+    [Exposed=(DedicatedWorker, Window), SecureContext]
+    interface Serial : EventTarget {
+      attribute EventHandler onconnect;
+      attribute EventHandler ondisconnect;
+      Promise&lt;sequence&lt;SerialPort>> getPorts();
+      [Exposed=Window] Promise&lt;SerialPort> requestPort(optional SerialPortRequestOptions options = {});
+    };
+  ```
+
+  ### <dfn>onconnect</dfn> attribute
+
+  ### <dfn>ondisconnect</dfn> attribute
+
+  ### <dfn>getPorts()</dfn> method
+
+  ### <dfn>requestPort()</dfn> method
+
+  The {{Serial/requestPort()}} method requests access to a serial port of the user's
+  choice (see [[[#security]]]).
+
+  When the {{Serial/requestPort()}} method is invoked, the user agent MUST perform the
+  following steps:
+
+  1. Let |promise:Promise| be [=a new promise=].
+  1. Return |promise| and run the remaining steps asynchronously.
+  1. Request access to a serial port (see [[[#security]]]):
+    1. If the access request is rejected, [=reject=] |promise| with an
+        {{"AbortError"}} {{DOMException}}.
+    1. Otherwise, let |port:SerialPort| be the {{SerialPort}} for which access
+        was granted.
+    1. [=Resolve=] |promise| with |port|.
+
+</section>
+
+<section data-dfn-for="SerialPort">
+  ## <dfn>SerialPort</dfn> interface
+
+  ```webidl
+  [Exposed=(DedicatedWorker,Window), SecureContext]
+  interface SerialPort {
+    readonly attribute ReadableStream readable;
+    readonly attribute WritableStream writable;
+
+    SerialPortInfo getInfo();
+
+    Promise&lt;void> open(SerialOptions options);
+    Promise&lt;void> setSignals(SerialOutputSignals signals);
+    Promise&lt;SerialInputSignals> getSignals();
+    void close();
+  };
+  ```
+
+  ### <dfn>readable</dfn> attribute
+
+  ### <dfn>writable</dfn> attribute
+
+  ### <dfn>getInfo()</dfn> method
+
+  The {{SerialPort/getInfo()}} method provides a means to get metadata corresponding to a
+  {{SerialPort}} object.
+
+  When the {{SerialPort/getInfo()}} method is invoked, the user agent MUST perform the
+  <a>steps for getting metadata of a serial port</a>.
+
+  ### <dfn>open()</dfn> method
+
+  ### <dfn>setSignals()</dfn> method
+
+  ### <dfn>getSignals()</dfn> method
+
+  ### <dfn>close()</dfn> method
+
+  When invoked on a {{SerialPort}} |port:SerialPort| the {{close()}} method,
+  the user agent MUST perform the following steps,
+
+  1. Let |cancelPromise:Promise| be the result of invoking
+    |port|.{{readable}}.<a data-cite="streams#rs-cancel">`cancel()`</a>.
+  1. Let |abortPromise:Promise| be the result of invoking
+    |port|.{{writable}}.<a data-cite="streams#ws-abort">`abort()`</a>.
+  1. Let |promise:Promise| be the result of
+    [=getting a promise to wait for all=] with «|cancelPromise|, |abortPromise|».
+  1. Return |promise|.
+
+</section>
+
+<section data-dfn-for="SerialPortInfo">
+  ## <dfn>SerialPortInfo</dfn> interface
+
+  ```webidl
+    [Exposed=(DedicatedWorker,Window), SecureContext]
+    interface SerialPortInfo {
+      maplike&lt;DOMString, DOMString?>;
+    };
+  ```
+
+  ### Serial port metadata
+
+  The value of certain attributes is dependent on the method that the system used
+  to establish the serial port (e.g., USB), and so might not always be available.
+
+  ### Recommended serial port metadata
+
+  When available, it is RECOMMENDED that user agents populate a {{SerialPortInfo}}
+  object with the following information. If the value of piece of metadata is
+  unavailable(e.g., if the manufacturer is unknown), then it is RECOMMENDED that
+  that metadata be excluded from the {{SerialPortInfo}}. For interoperability,
+  user agents SHOULD use the values provided in they "Key" column of the
+  <a>table of recommended metadata</a>.
+
+  <table class="simple">
+    <caption><dfn>Table of recommended metadata</dfn></caption>
+    <tr>
+      <th>Name</th>
+      <th>Key</th>
+      <th>Description</th>
+    </tr>
+    <tr>
+      <td>Serial Number</td>
+      <td>`serialNumber`</td>
+      <td></td>
+    </tr>
+    <tr>
+      <td>Manufacturer</td>
+      <td>`manufacturer`</td>
+      <td></td>
+    </tr>
+    <tr>
+      <td>Location ID</td>
+      <td>`locationId`</td>
+      <td></td>
+    </tr>
+    <tr>
+      <td>Vendor ID</td>
+      <td>`vendorId`</td>
+      <td></td>
+    </tr>
+    <tr>
+      <td>Vendor</td>
+      <td>`vendor`</td>
+      <td></td>
+    </tr>
+    <tr>
+      <td>Product ID</td>
+      <td>`productId`</td>
+      <td></td>
+    </tr>
+    <tr>
+      <td>Product</td>
+      <td>`product`</td>
+      <td></td>
+    </tr>
+  </table>
+
+  ### Getting serial port metadata
+
+  The <dfn>steps for getting metadata of a serial port</dfn> for a |serial
+  port| are as follows. The steps always return an instance of
+  {{SerialPortInfo}}, which contains the related metadata.
+
+  1. Let |info:SerialPortInfo| be a newly created {{SerialPortInfo}} object.
+  1. Let |path:DOMString| be a {{DOMString}} that represents the path of the |serial port|.
+  1. Invoke |info|'s `set()` method using the string `"path"` as the
+     key, and |path| as the value.
+  1. For each additional metadata item known about the |serial port|,
+      perform the following sub-steps. Please see the <a>table of recommended
+      metadata</a> for a list of recommended metadata items that SHOULD be
+      included.
+      1. Let |key:DOMString| be a {{DOMString}} for the commonly used name for this
+        key.
+      1. Let |value:DOMString| be a {{DOMString}} for the commonly used name for
+        this key, or `null` otherwise.
+      1. Invoke |info|'s `set()` method using the string "path" as the
+        key, and |path| as the value.
+  1. Return |info|.
+
+</section>
+
+<section data-dfn-for="SerialOptions">
+  ## <dfn>SerialOptions</dfn> dictionary
+
+  ```webidl
+    dictionary SerialOptions {
+      required unsigned long baudrate;
+      octet databits = 8;
+      octet stopbits = 1;
+      ParityType parity = "none";
+      unsigned long buffersize = 255;
+      boolean rtscts = false;
+    };
+  ```
+
+  <dl data-dfn-for="SerialOptions">
+    <dt>
+      <dfn>baudrate</dfn> member
+    </dt>
+    <dd>
+      A positive, non-zero value indicating the baud rate at which serial
+      communication should be established.
+    </dd>
+    <dt>
+      <dfn>databits</dfn> member
+    </dt>
+    <dd>
+      The number of data bits per frame. Either 7 or 8.
+    </dd>
+    <dt>
+      <dfn>stopbits</dfn> member
+    </dt>
+    <dd>
+      The number of stop bits at the end of a frame. Either 1 or 2.
+    </dd>
+    <dt>
+      <dfn>parity</dfn> member'
+    </dt>
+    <dd>
+      The parity mode.
+    </dd>
+    <dt>
+      <dfn>buffersize</dfn> member
+    </dt>
+    <dd>
+      A positive, non-zero value indicating the size of the read and write
+      buffers that should be created.
+    </dd>
+    <dt>
+      <dfn>rtscts</dfn> member
+    </dt>
+    <dd>
+      If set to <code>true</code> then hardware flow control will be enabled.
+    </dd>
+  </dl>
+</section>
+
+<section data-dfn-for="ParityType">
+  ## <dfn>ParityType</dfn> enum</h2>
+
+  ```webidl
+  enum ParityType {
+    "none",
+    "even",
+    "odd"
+  };
+  ```
+  <dl>
+    <dt><dfn>none</dfn></dt>
+    <dd>No parity bit is sent for each data word.</dd>
+    <dt><dfn>even</dfn></dt>
+    <dd>Data word plus parity bit has even parity.</dd>
+    <dt><dfn>odd</dfn></dt>
+    <dd>Data word plus parity bit has odd parity.</dd>
+  </dl>
+</section>
+
+<section data-dfn-for="SerialInputSignals">
+  ## <dfn>SerialInputSignals</dfn> dictionary
+
+  ```webidl
   dictionary SerialInputSignals {
     required boolean dcd;
     required boolean cts;
     required boolean ri;
     required boolean dsr;
   };
-</pre>
-<dl data-dfn-for="SerialInputSignals">
-  <dt><dfn>dcd</dfn> member</dt>
-  <dd>Data Carrier Detect</dd>
-  <dt><dfn>cts</dfn> member</dt>
-  <dd>Clear To Send</dd>
-  <dt><dfn>ri</dfn> member</dt>
-  <dd>Ring Indicator</dd>
-  <dt><dfn>dsr</dfn> member</dt>
-  <dd>Data Set Ready</dd>
-</dl>
+  ```
+  <dl>
+    <dt><dfn>dcd</dfn> member</dt>
+    <dd>Data Carrier Detect</dd>
+    <dt><dfn>cts</dfn> member</dt>
+    <dd>Clear To Send</dd>
+    <dt><dfn>ri</dfn> member</dt>
+    <dd>Ring Indicator</dd>
+    <dt><dfn>dsr</dfn> member</dt>
+    <dd>Data Set Ready</dd>
+  </dl>
 </section>
 
-<section data-dfn-for="SerialOutputSignals" data-link-for="SerialOutputSignals">
-## <dfn>SerialOutputSignals</dfn> dictionary
-<pre class="idl">
-  dictionary SerialOutputSignals {
-    boolean dtr;
-    boolean rts;
-    boolean brk;
-  };
-</pre>
-<dl data-dfn-for="SerialOutputSignals">
-  <dt><dfn>dtr</dfn></dt>
-  <dd>Data Terminal Ready</dd>
-  <dt><dfn>rts</dfn></dt>
-  <dd>Request To Send</dd>
-  <dt><dfn>brk</dfn></dt>
-  <dd>Break</dd>
-</dl>
+<section data-dfn-for="SerialOutputSignals">
+  ## <dfn>SerialOutputSignals</dfn> dictionary
+
+  ```webidl
+    dictionary SerialOutputSignals {
+      boolean dtr;
+      boolean rts;
+      boolean brk;
+    };
+  ```
+  <dl>
+    <dt><dfn>dtr</dfn></dt>
+    <dd>Data Terminal Ready</dd>
+    <dt><dfn>rts</dfn></dt>
+    <dd>Request To Send</dd>
+    <dt><dfn>brk</dfn></dt>
+    <dd>Break</dd>
+  </dl>
 </section>
 
 <section>
-## Serial port source abstract operations
+  ## Serial port source abstract operations
 
-## <dfn>SerialPortSourcePullAlgorithm</dfn>(|port:SerialPort|, |controller:ReadableStreamDefaultController|)
+  ## <dfn>SerialPortSourcePullAlgorithm</dfn>(|port:SerialPort|, |controller:ReadableStreamDefaultController|)
 
-<ol>
-  <li>Let |promise:Promise| be [=a new promise=].</li>
-  <li>[=Resolve=] |promise|.</li>
-  <li>
-    Return |promise| and run the following steps [=in parallel=]:
-    <ol>
-      <li>
-        Let |desiredSize| be |controller|.
-        <a data-cite="streams#rs-default-controller-desired-size">`desiredSize`</a>.
-      </li>
-      <li>
-        Let |buffer| be a newly created {{ArrayBuffer}} of |desiredSize| bytes.
-      </li>
-      <li>
-        Invoke the operating system to read up to |desiredSize| bytes from
-        |port| into |buffer|.
-      </li>
-      <li>
-        If no errors were encountered run the following steps:
-        <ol>
-          <li>Let |bytesRead| be the number of bytes written to |buffer|.</li>
-          <li>
-            Let |chunk| be a newly created {{Uint8Array}} over the slice of
-            |buffer| from `0` to |bytesRead|.
-          <li>
-            Invoke |controller|.
-            <a data-cite="streams#rs-default-controller-enqueue">`enqueue()`</a>
-            with |chunk|.
-          </li>
-        </ol>
-      <li>
-        If a buffer overrun condition was encountered, invoke
-        |controller|.
-        <a data-cite="streams#rs-default-controller-error">`error()`</a> with a
+  1. Let |promise:Promise| be [=a new promise=].
+  1. [=Resolve=] |promise|.
+  1. Return |promise| and run the remaining steps [=in parallel=]:
+    1. Let |desiredSize| be |controller|.{{`desiredSize`}}
+    1. Let |buffer| be a newly created {{ArrayBuffer}} of |desiredSize| bytes.
+    1. Invoke the operating system to read up to |desiredSize| bytes from |port| into |buffer|.
+    1. If no errors were encountered run the following steps:
+      1. Let |bytesRead| be the number of bytes written to |buffer|.
+      1. Let |chunk| be a newly created {{Uint8Array}} over the slice of
+          |buffer| from `0` to |bytesRead|.
+      1. Invoke |controller|.{{ReadableStreamDefaultController/enqueue()}} with |chunk|.
+    1. If a buffer overrun condition was encountered, invoke
+        |controller|.{{ReadableStreamDefaultController/error()}} with a
         <dfn>`BufferOverrunError`</dfn>.
-      </li>
-      <li>
-        If a break condition was encountered, invoke |controller|.
-        <a data-cite="streams#rs-default-controller-error">`error()`</a> with a
-        <dfn>`BreakError`</dfn>.
-      </li>
-      <li>
-        If a framing error was encountered, invoke |controller|.
-        <a data-cite="streams#rs-default-controller-error">`error()`</a> with a
-        <dfn>`FramingError`</dfn>.
-      </li>
-      <li>
-        If a parity error was encountered, invoke |controller|.
-        <a data-cite="streams#rs-default-controller-error">`error()`</a> with a
-        <dfn>`ParityError`</dfn>.
-      </li>
-      <li>
-        If an operating system error was encountered, invoke
-        |controller|.
-        <a data-cite="streams#rs-default-controller-error">`error()`</a> with an
-        {{UnknownError}}.
-      </li>
-      <li>
-        If |port| was disconnected, invoke |controller|.
-        <a data-cite="streams#rs-default-controller-error">`error()`</a> with a
-        {{NetworkError}}.
-      </li>
-    </ol>
-  </li>
-</ol>
+    1. If a break condition was encountered, invoke
+        |controller|.{{ReadableStreamDefaultController/error()}}
+        with a <dfn>`BreakError`</dfn>.
+    1. If a framing error was encountered,
+        invoke |controller|.{{ReadableStreamDefaultController/error()}}
+        with a <dfn>`FramingError`</dfn>.
+    1. If a parity error was encountered,
+        invoke |controller|.{{ReadableStreamDefaultController/error()}}
+        with a <dfn>`ParityError`</dfn>.
+    1. If an operating system error was encountered,
+        invoke |controller|.{{ReadableStreamDefaultController/error()}}
+        with a <dfn>`UnknownError`</dfn>.
+    1. If |port| was disconnected,
+        invoke |controller|.{{ReadableStreamDefaultController/error()}}
+        with a {{NetworkError}}.
 
-<p class="note">
-The {{Promise}} returned by this algorithm is immediately resolved so that it
-does not block canceling the stream. [[STREAMS]] specifies that this algorithm
-will not be invoked again until a chunk is enqueued.
-</p>
+  <p class="note">
+  The {{Promise}} returned by this algorithm is immediately resolved so that it
+  does not block canceling the stream. [[STREAMS]] specifies that this algorithm
+  will not be invoked again until a chunk is enqueued.
+  </p>
 
-## <dfn>SerialPortSourceCancelAlgorithm</dfn>(|port:SerialPort|)
+  ## <dfn>SerialPortSourceCancelAlgorithm</dfn>(|port:SerialPort|)
 
-1. Let |promise| be [=a new promise=].
-1. [=In parallel=], invoke the operating system to discard the contents of all
-   software and hardware receive buffers for |port| and [=resolve=] |promise|.
-1. Return |promise|.
+  1. Let |promise| be [=a new promise=].
+  1. [=In parallel=], invoke the operating system to discard the contents of all
+    software and hardware receive buffers for |port| and [=resolve=] |promise|.
+  1. Return |promise|.
+
 </section>
 
 <section>
-## Serial port sink abstract operations
+  ## Serial port sink abstract operations
 
-## <dfn>SerialPortSinkWriteAlgorithm</dfn>(|port:SerialPort|, |chunk:Uint8Array|)
+  ## <dfn>SerialPortSinkWriteAlgorithm</dfn>(|port:SerialPort|, |chunk:Uint8Array|)
 
-1. Let |promise:Promise| be [=a new promise=].
-1. [=In parallel=], run the following steps:
-<ol>
-   1. Invoke the operating system to write |chunk| to |port|.
-   1. If the chunk was successfully written [=resolve=] |promise|.
-   1. If an operating system error was encountered, [=reject=] |promise| with an
-      {{UnknownError}}.
-   1. If |port| was disconnected, [=reject=] |promise| with a {{NetworkError}}.
-</ol>
-1. Return |promise|.
+  1. Let |promise:Promise| be [=a new promise=].
+  1. [=In parallel=], run the following steps:
+    1. Invoke the operating system to write |chunk| to |port|.
+    1. If the chunk was successfully written [=resolve=] |promise|.
+    1. If an operating system error was encountered, [=reject=] |promise| with an
+        {{UnknownError}}.
+    1. If |port| was disconnected, [=reject=] |promise| with a {{NetworkError}}.
+  1. Return |promise|.
 
-<p class="note">
-[[STREAMS]] specifies that {{SerialPortSinkWriteAlgorithm}} will only be invoked
-after the {{Promise}} returned by a previous invocation of this algorithm has
-resolved. This prevents implementations from coalescing multiple chunks waiting
-in the {{WritableStream}}'s internal queue into a single request to the
-operating system.
-</p>
+  <p class="note">
+  [[STREAMS]] specifies that {{SerialPortSinkWriteAlgorithm}} will only be invoked
+  after the {{Promise}} returned by a previous invocation of this algorithm has
+  resolved. This prevents implementations from coalescing multiple chunks waiting
+  in the {{WritableStream}}'s internal queue into a single request to the
+  operating system.
+  </p>
 
-## <dfn>SerialPortSinkAbortAlgorithm</dfn>(|port:SerialPort|)
+  ## <dfn>SerialPortSinkAbortAlgorithm</dfn>(|port:SerialPort|)
 
-1. Let |promise| be [=a new promise=].
-1. [=In parallel=], invoke the operating system to discard the contents of all
-   software and hardware transmit buffers for |port| and [=resolve=] |promise|.
-1. Return |promise|.
+  1. Let |promise| be [=a new promise=].
+  1. [=In parallel=], invoke the operating system to discard the contents of all
+    software and hardware transmit buffers for |port| and [=resolve=] |promise|.
+  1. Return |promise|.
 
-<p class="note">
-[[STREAMS]] specifies that {{SerialPortSinkAbortAlgorithm}} will only be invoked
-after the {{Promise}} returned by a previous invocation of
-{{SerialPortSinkWriteAlgorithm}} (if any) has resolved. This blocks abort on
-completion of the most recent write operation. This could be fixed by passing an
-{{AbortSignal}} to {{SerialPortSinkWriteAlgorithm}}.
-</p>
+  <p class="note">
+  [[STREAMS]] specifies that {{SerialPortSinkAbortAlgorithm}} will only be invoked
+  after the {{Promise}} returned by a previous invocation of
+  {{SerialPortSinkWriteAlgorithm}} (if any) has resolved. This blocks abort on
+  completion of the most recent write operation. This could be fixed by passing an
+  {{AbortSignal}} to {{SerialPortSinkWriteAlgorithm}}.
+  </p>
 
-## <dfn>SerialPortSinkCloseAlgorithm</dfn>(|port:SerialPort|)
+  ## <dfn>SerialPortSinkCloseAlgorithm</dfn>(|port:SerialPort|)
 
-1. Let |promise| be [=a new promise=].
-1. [=In parallel=], invoke the operating system to flush the contents of all
-   software and hardware transmit buffers for |port| and [=resolve=] |promise|.
+  1. Let |promise| be [=a new promise=].
+  1. [=In parallel=], invoke the operating system to flush the contents of all
+    software and hardware transmit buffers for |port| and [=resolve=] |promise|.
+
 </section>
 
-## Security considerations
+<section id="security">
+  ## Security considerations
 
-This section defines the <dfn>Security considerations</dfn> for the <cite>
-Serial API</cite>.
+  This section defines the <dfn>Security considerations</dfn> for the <cite>
+  Serial API</cite>.
 
-It is RECOMMENDED that an user interface be presented to the user to allow them
-to select the serial ports that the page can access. Such an interface would
-allow an end user to select zero ore more serial ports on the device - or to
-reject the request to access any ports.
+  It is RECOMMENDED that an user interface be presented to the user to allow them
+  to select the serial ports that the page can access. Such an interface would
+  allow an end user to select zero ore more serial ports on the device - or to
+  reject the request to access any ports.
 
-A user agent SHOULD allow the user to select from all serial ports available
-on the machine, and be shown an indicator for serial ports that are currently
-busy, either as a result of prior calls to `requestPorts()` or are in
-use by the system.
+  A user agent SHOULD allow the user to select from all serial ports available
+  on the machine, and be shown an indicator for serial ports that are currently
+  busy, either as a result of prior calls to `requestPorts()` or are in
+  use by the system.
 
-It is also RECOMMENDED that user agents provide users with a means for the end-
-user to view which independently of any access request, and be given the
-ability to revoke individual or complete access to serial ports at any time
-either at the user agent level or per [origin](http://www.whatwg.org/specs/web-apps/current-work/#origin-0)
-[[HTML]].
+  It is also RECOMMENDED that user agents provide users with a means for the end-
+  user to view which independently of any access request, and be given the
+  ability to revoke individual or complete access to serial ports at any time
+  either at the user agent level or per [=origin=].
+</section>
 
 <section class="informative">
-## Use cases and requirements
+  ## Use cases and requirements
 
-### Hardware disconnection
-Some devices allow users to manually reset the connection between the user
-agent and the physical device (e.g., by pushing a button). One example
-device is the Arduino. Another example is the user abruptly disconnecting
-one device from another, thus severing the communication channel.
+  ### Hardware disconnection
+  Some devices allow users to manually reset the connection between the user
+  agent and the physical device (e.g., by pushing a button). One example
+  device is the Arduino. Another example is the user abruptly disconnecting
+  one device from another, thus severing the communication channel.
 
-As such, it is a requirement that the API gracefully handle abrupt
-disconnection caused by a reset or other event. When such disconnections
-occur, the API must make it possible for the developer to be notified of such
-disconnections. When possible, the API should provide details about the
-disconnection (e.g., reason, time, etc.).
+  As such, it is a requirement that the API gracefully handle abrupt
+  disconnection caused by a reset or other event. When such disconnections
+  occur, the API must make it possible for the developer to be notified of such
+  disconnections. When possible, the API should provide details about the
+  disconnection (e.g., reason, time, etc.).
 
-### Baud rates
-Traditionally, serial devices have operated at
-[baud rates](http://en.wikipedia.org/wiki/Baud)
-of between 50 and 115,200 bps.
+  ### Baud rates
+  Traditionally, serial devices have operated at
+  [baud rates](http://en.wikipedia.org/wiki/Baud)
+  of between 50 and 115,200 bps.
 
-However, modern USB serial devices are able to operate at significantly higher
-baud rates than legacy hardware. For example, the
-[bioloid servos](http://support.robotis.com/en/techsupport_eng.htm#product/dynamixel/ax_series/dxl_ax_actuator.htm)
-operate at 1 Mbit (1,000,000 bps). Other USB-to-serial chips are able to
- operate at 3 MBit (3,000,000bps).
+  However, modern USB serial devices are able to operate at significantly higher
+  baud rates than legacy hardware. For example, the
+  [bioloid servos](http://support.robotis.com/en/techsupport_eng.htm#product/dynamixel/ax_series/dxl_ax_actuator.htm)
+  operate at 1 Mbit (1,000,000 bps). Other USB-to-serial chips are able to
+  operate at 3 MBit (3,000,000bps).
 
-Additionally, other serial devices have standardized baud rates that
-are not in the commonly accepted value for baud rates. For example,
-[MIDI](http://en.wikipedia.org/wiki/MIDI) uses a baud rate of 31,250 bps,
-while a [DMX512 controller](http://en.wikipedia.org/wiki/DMX512)
-transmits data at 250kbps.
+  Additionally, other serial devices have standardized baud rates that
+  are not in the commonly accepted value for baud rates. For example,
+  [MIDI](http://en.wikipedia.org/wiki/MIDI) uses a baud rate of 31,250 bps,
+  while a [DMX512 controller](http://en.wikipedia.org/wiki/DMX512)
+  transmits data at 250kbps.
 
-As such, it is a requirement that the Serial API does not limit the
-baud rates to a traditional range. Instead, the API must allow a
-developer to specify any rate so long as the value is an unsigned number.
-If there is a baud rate that is common for a large range of hardware that
-will make use of this API, the API should provide a default baud rate value.
+  As such, it is a requirement that the Serial API does not limit the
+  baud rates to a traditional range. Instead, the API must allow a
+  developer to specify any rate so long as the value is an unsigned number.
+  If there is a baud rate that is common for a large range of hardware that
+  will make use of this API, the API should provide a default baud rate value.
 
-Given the above requirement, it is possible to create software to wrap the
-Serial API to restrict the possible baud rates used for communicating with some
-particular hardware. For example, a JavaScript library that communicates with
-a MIDI device could automatically set the baud rate to 31,250 bps without
-needing to bother the developer to specify the value.
+  Given the above requirement, it is possible to create software to wrap the
+  Serial API to restrict the possible baud rates used for communicating with some
+  particular hardware. For example, a JavaScript library that communicates with
+  a MIDI device could automatically set the baud rate to 31,250 bps without
+  needing to bother the developer to specify the value.
 </section>
+
+<section id="conformance"></section>
+
 <section class='appendix'>
-## Acknowledgements
-... coming soon...
-</section>
+  ## Acknowledgements
 
+  The following people contributed to the development of this document.
+
+  <ul id="gh-contributors"></ul>
+</section>

--- a/index.html
+++ b/index.html
@@ -103,15 +103,16 @@ choice (see <a>security considerations</a>).
 When the <a>requestPort()</a> method is invoked, the user agent MUST perform the
 following steps:
 
- 1. Let <var>promise</var> be a newly created <a data-cite="webidl#promise">`Promise`</a>.
- 1. Return <var>promise</var> and run the remaining steps asynchronously.
- 1. Request access to a serial port (see <a>security considerations</a>):
+1. Let <var>promise</var> be
+   <a data-cite="webidl#a-new-promise">a new promise</a>.
+1. Return <var>promise</var> and run the remaining steps asynchronously.
+1. Request access to a serial port (see <a>security considerations</a>):
    1. If the access request is rejected
-      <a data-cite="promises-guide#reject-promise">reject</a> <var>promise</var>
+      <a data-cite="webidl#reject">reject</a> <var>promise</var>
       with <a data-cite="webidl#aborterror">`AbortError`</a> and terminate this
       algorithm.
    1. Otherwise, let <var>port</var> be the <a>`SerialPort`</a> for which access
-      was granted and <a data-cite="promises-guide#resolve-promise">resolve</a>
+      was granted and <a data-cite="webidl#resolve">resolve</a>
       <var>promise</var> with <var>port</var>.
 </section>
 
@@ -153,9 +154,19 @@ When the <a>getInfo()</a> method is invoked, the user agent MUST perform the
 
 ## <dfn>close()</dfn> method
 
-When invoked on a {{SerialPort}} <var>port</var> the <a>close()</a> method
-returns the result of
-`Promise.all([port.readable.cancel(), port.writable.abort()])`.
+
+
+When invoked on a {{SerialPort}} <var>port</var> the <a>close()</a> method,
+the user agent MUST perform the following steps,
+
+1. Let <var>cancelPromise</var> be the result of invoking
+   <var>port</var>.{{readable}}.<a data-cite="streams#rs-cancel">`cancel()`</a>.
+1. Let <var>abortPromise</var> be the result of invoking
+   <var>port</var>.{{writable}}.<a data-cite="streams#ws-abort">`abort()`</a>.
+1. Let <var>promise</var> be the result of
+   <a data-cite="webidl#waiting-for-all-promise">getting a promise to wait for
+   all</a> with «<var>cancelPromise</var>, <var>abortPromise</var>».
+1. Return <var>promise</var>.
 
 </section>
 
@@ -373,9 +384,9 @@ enum ParityType {
 
 ## <dfn>SerialPortSourcePullAlgorithm</dfn>(<var>port</var>, <var>controller</var>)
 
-1. Let <var>promise</var> be a newly created
-   <a data-cite="webidl#promise">`Promise`</a>.
-1. Resolve <var>promise</var>.
+1. Let <var>promise</var> be
+   <a data-cite="webidl#a-new-promise">a new promise</a>.
+1. <a data-cite="webidl#resolve">Resolve</a> <var>promise</var>.
 1. Return <var>promise</var> and run the following steps <a data-cite="html#in-parallel">in parallel</a>:
     1. Let <var>desiredSize</var> be <var>controller</var>.
        <a data-cite="streams#rs-default-controller-desired-size">`desiredSize`</a>.
@@ -427,7 +438,8 @@ enqueued.
    <a data-cite="webidl#promise">`Promise`</a>.
 1. <a data-cite="html#in-parallel">In parallel</a>, invoke the operating system
    to discard the contents of all software and hardware receive buffers for
-   <var>port</var> and resolve <var>promise</var>.
+   <var>port</var> and <a data-cite="webidl#resolve">resolve</a>
+   <var>promise</var>.
 1. Return <var>promise</var>.
 </section>
 
@@ -440,10 +452,13 @@ enqueued.
    <a data-cite="webidl#promise">`Promise`</a>.
 1. <a data-cite="html#in-parallel">In parallel</a>, run the following steps:
    1. Invoke the operating system to write <var>chunk</var> to <var>port</var>.
-   1. If the chunk was successfully written resolve <var>promise</var>.
-   1. If an operating system error was encountered, reject <var>promise</var>
+   1. If the chunk was successfully written
+      <a data-cite="webidl#resolve">resolve</a> <var>promise</var>.
+   1. If an operating system error was encountered,
+      <a data-cite="webidl#reject">reject</a> <var>promise</var>
       with an <a data-cite="webidl#unknownerror">`UnknownError`</a>.
-   1. If <var>port</var> was disconnected, reject <var>promise</var> with a
+   1. If <var>port</var> was disconnected,
+      <a data-cite="webidl#reject">reject</a> <var>promise</var> with a
       <a data-cite="webidl#networkerror">`NetworkError`</a>.
 1. Return <var>promise</var>.
 
@@ -458,29 +473,31 @@ single request to the operating system.
 
 ## <dfn>SerialPortSinkAbortAlgorithm</dfn>(<var>port</var>, <var>reason</var>)
 
-1. Let <var>promise</var> be a newly created
-   <a data-cite="webidl#promise">`Promise`</a>.
+1. Let <var>promise</var> be
+   <a data-cite="webidl#a-new-promise">a new promise</a>.
 1. <a data-cite="html#in-parallel">In parallel</a>, invoke the operating system
    to discard the contents of all software and hardware transmit buffers for
-   <var>port</var> and resolve <var>promise</var>.
+   <var>port</var> and <a data-cite="webidl#resolve">resolve</a>
+   <var>promise</var>.
 1. Return <var>promise</var>.
 
 <p class="note">
 [[STREAMS]] specifies that {{SerialPortSinkAbortAlgorithm}} will only be invoked
-after the <a data-cite="webidl#promise">`Promise`</a> returned by a previous
+after the <a data-cite="webidl#idl-promise">`Promise`</a> returned by a previous
 invokation of {{SerialPortSinkWriteAlgorithm}} (if any) has resolved. This
 blocks abort on completion of the most recent write operation. This could be
-fixed by passing an <a data-cite="dom#interface-AbortSignal">`AbortSignal`</a>
+fixed by passing an <a data-cite="dom#abortsignal">`AbortSignal`</a>
 to {{SerialPortSinkWriteAlgorithm}}.
 </p>
 
 ## <dfn>SerialPortSinkCloseAlgorithm</dfn>(<var>port</var>)
 
-1. Let <var>promise</var> be a newly created
-   <a data-cite="webidl#promise">`Promise`</a>.
+1. Let <var>promise</var> be
+   <a data-cite="webidl#a-new-promise">a new promise</a>.
 1. <a data-cite="html#in-parallel">In parallel</a>, invoke the operating system
    to flush the contents of all software and hardware transmit buffers for
-   <var>port</var> and resolve <var>promise</var>.
+   <var>port</var> and <a data-cite="webidl#resolve">resolve</a>
+   <var>promise</var>.
 </section>
 
 ## Security considerations

--- a/index.html
+++ b/index.html
@@ -446,7 +446,7 @@ for use.
   perform the following steps for each script execution environment:
 
   1. Let |port:SerialPort| be the {{SerialPort}} object representing the new
-      serial port connected.
+      serial port connected (see [[[#security]]]).
   1. Let |event:SerialConnectionEvent| be a new {{SerialConnectionEvent}}, with
       its {{SerialConnectionEvent/port}} attribute set to |port|.
   1. Fire an event named <dfn>connect</dfn> on {{Navigator/serial}}, using

--- a/index.html
+++ b/index.html
@@ -91,12 +91,12 @@ for use.
 
   ### <dfn>onconnect</dfn> attribute
 
-  The {{Serial/onconnect}} attribute is an Event handler IDL attribute for the
+  The {{Serial/onconnect}} attribute is an <a>event handler IDL attribute</a> for the
   {{connect}} event type.
 
   ### <dfn>ondisconnect</dfn> attribute
 
-  The {{Serial/ondisconnect}} attribute is an Event handler IDL attribute for
+  The {{Serial/ondisconnect}} attribute is an <a>event handler IDL attribute</a> for
   the {{disconnect}} event type.
 
   ### <dfn>getPorts()</dfn> method

--- a/index.html
+++ b/index.html
@@ -91,7 +91,13 @@ for use.
 
   ### <dfn>onconnect</dfn> attribute
 
+  The {{Serial/onconnect}} attribute is an Event handler IDL attribute for the
+  {{connect}} event type.
+
   ### <dfn>ondisconnect</dfn> attribute
+
+  The {{Serial/ondisconnect}} attribute is an Event handler IDL attribute for
+  the {{disconnect}} event type.
 
   ### <dfn>getPorts()</dfn> method
 
@@ -407,6 +413,58 @@ for use.
     <dt><dfn>brk</dfn></dt>
     <dd>Break</dd>
   </dl>
+</section>
+
+<section>
+  ## Events
+
+  ```webidl
+    dictionary SerialConnectionEventInit : EventInit {
+      required SerialPort port;
+    };
+
+    [Exposed=(DedicatedWorker,Window), SecureContext]
+    interface SerialConnectionEvent : Event {
+      constructor(DOMString type, SerialConnectionEventInit eventInitDict);
+      [SameObject] readonly attribute SerialPort port;
+    };
+  ```
+
+  <pre class="example js" title="Keep UI in sync with connected and disconnected serial ports">
+    navigator.serial.addEventListener('connect', event => {
+      // Add |event.port| to the UI.
+    });
+
+    navigator.serial.addEventListener('disconnect', event => {
+      // Remove |event.port| from the UI.
+    });
+  </pre>
+
+  ### Serial port connection
+
+  When the UA detects a new serial port connected to the host it MUST
+  perform the following steps for each script execution environment:
+
+  1. Let |port| be the {{SerialPort}} object representing the new serial port
+      connected.
+  1. Let |event| be a new {{SerialConnectionEvent}}, with its
+      {{SerialConnectionEvent/port}} attribute set to |port|.
+  1. Fire an event named <dfn>connect</dfn> on {{Navigator/serial}}, using
+      |event| as the event object.
+
+
+  ### Serial port disconnection
+
+  When the UA detects a serial port has been disconnected from the host it
+  MUST perform the following steps for each script execution environment:
+
+  1. Let |port| be the {{SerialPort}} object representing the serial port
+      disconnected.
+  1. Let |event| be a new {{SerialConnectionEvent}}, with its
+      {{SerialConnectionEvent/port}} attribute set to |port|.
+  1. Fire an event named <dfn>disconnect</dfn> on {{Navigator/serial}}, using
+      |event| as the event object.
+
 </section>
 
 <section>

--- a/index.html
+++ b/index.html
@@ -445,10 +445,10 @@ for use.
   When the UA detects a new serial port connected to the host it MUST
   perform the following steps for each script execution environment:
 
-  1. Let |port| be the {{SerialPort}} object representing the new serial port
-      connected.
-  1. Let |event| be a new {{SerialConnectionEvent}}, with its
-      {{SerialConnectionEvent/port}} attribute set to |port|.
+  1. Let |port:SerialPort| be the {{SerialPort}} object representing the new
+      serial port connected.
+  1. Let |event:SerialConnectionEvent| be a new {{SerialConnectionEvent}}, with
+      its {{SerialConnectionEvent/port}} attribute set to |port|.
   1. Fire an event named <dfn>connect</dfn> on {{Navigator/serial}}, using
       |event| as the event object.
 

--- a/index.html
+++ b/index.html
@@ -75,7 +75,7 @@ the <a>Serial</a> object.
 
 <section data-dfn-for="Serial" data-link-for="Serial">
 ## <dfn>Serial</dfn> interface
-<pre class="idl" data-cite="DOM HTML">
+<pre class="idl">
 dictionary SerialPortRequestOptions {
 };
 
@@ -103,23 +103,19 @@ choice (see <a>security considerations</a>).
 When the <a>requestPort()</a> method is invoked, the user agent MUST perform the
 following steps:
 
-1. Let <var>promise</var> be
-   <a data-cite="webidl#a-new-promise">a new promise</a>.
-1. Return <var>promise</var> and run the remaining steps asynchronously.
+1. Let |promise:Promise| be [=a new promise=].
+1. Return |promise| and run the remaining steps asynchronously.
 1. Request access to a serial port (see <a>security considerations</a>):
-   1. If the access request is rejected
-      <a data-cite="webidl#reject">reject</a> <var>promise</var>
-      with <a data-cite="webidl#aborterror">`AbortError`</a> and terminate this
-      algorithm.
-   1. Otherwise, let <var>port</var> be the <a>`SerialPort`</a> for which access
-      was granted and <a data-cite="webidl#resolve">resolve</a>
-      <var>promise</var> with <var>port</var>.
+   1. If the access request is rejected [=reject=] |promise| with {{AbortError}}
+      and terminate this algorithm.
+   1. Otherwise, let |port:SerialPort| be the {{SerialPort}} for which access
+      was granted and [=resolve=] |promise| with |port|.
 </section>
 
 <section data-dfn-for="SerialPort" data-link-for="SerialPort">
 <h2><dfn>SerialPort</dfn> interface</h2>
 
-<pre class="idl" data-cite="STREAMS">
+<pre class="idl">
 [Exposed=(DedicatedWorker,Window), SecureContext]
 interface SerialPort {
   readonly attribute ReadableStream readable;
@@ -156,17 +152,16 @@ When the <a>getInfo()</a> method is invoked, the user agent MUST perform the
 
 
 
-When invoked on a {{SerialPort}} <var>port</var> the <a>close()</a> method,
+When invoked on a {{SerialPort}} |port:SerialPort| the {{close()}} method,
 the user agent MUST perform the following steps,
 
-1. Let <var>cancelPromise</var> be the result of invoking
-   <var>port</var>.{{readable}}.<a data-cite="streams#rs-cancel">`cancel()`</a>.
-1. Let <var>abortPromise</var> be the result of invoking
-   <var>port</var>.{{writable}}.<a data-cite="streams#ws-abort">`abort()`</a>.
-1. Let <var>promise</var> be the result of
-   <a data-cite="webidl#waiting-for-all-promise">getting a promise to wait for
-   all</a> with «<var>cancelPromise</var>, <var>abortPromise</var>».
-1. Return <var>promise</var>.
+1. Let |cancelPromise:Promise| be the result of invoking
+   |port|.{{readable}}.<a data-cite="streams#rs-cancel">`cancel()`</a>.
+1. Let |abortPromise:Promise| be the result of invoking
+   |port|.{{writable}}.<a data-cite="streams#ws-abort">`abort()`</a>.
+1. Let |promise:Promise| be the result of
+   [=getting a promise to wait for all=] with «|cancelPromise|, |abortPromise|».
+1. Return |promise|.
 
 </section>
 
@@ -240,27 +235,27 @@ user agents SHOULD use the values provided in they "Key" column of the
 
 ### Getting serial port metadata
 
-The <dfn>steps for getting metadata of a serial port</dfn> for a <var>serial
-port</var> are as follows. The steps always return an instance of
+The <dfn>steps for getting metadata of a serial port</dfn> for a |serial
+port| are as follows. The steps always return an instance of
 `SerialPortInfo`, which contains the related metadata.
 
- 1. Let <var>info</var> be an object that implements the `SerialPortInfo`
+ 1. Let |info| be an object that implements the `SerialPortInfo`
     interface.
- 1. Let <var>path</var> be a `DOMString` that represents the path of the
-    <var>serial port</var>.
- 1. Invoke <var>info</var>'s `set()` method using the string `"path"` as the
-    key, and <var>path</var> as the value.
- 1. For each additional metadata item known about the <var>serial port</var>,
+ 1. Let |path| be a `DOMString` that represents the path of the
+    |serial port|.
+ 1. Invoke |info|'s `set()` method using the string `"path"` as the
+    key, and |path| as the value.
+ 1. For each additional metadata item known about the |serial port|,
     perform the following sub-steps. Please see the <a>table of recommended
     metadata</a> for a list of recommended metadata items that SHOULD be
     included.
-    1. Let <var>key</var> be a `DOMString` for the commonly used name for this
+    1. Let |key| be a `DOMString` for the commonly used name for this
        key.
-    1. Let <var>value</var> be a `DOMString` for the commonly used name for
+    1. Let |value| be a `DOMString` for the commonly used name for
        this key, or `null` otherwise.
-    1. Invoke <var>info</var>'s `set()` method using the string "path" as the
-       key, and <var>path</var> as the value.
- 1. Return <var>info</var>.
+    1. Invoke |info|'s `set()` method using the string "path" as the
+       key, and |path| as the value.
+ 1. Return |info|.
 </section>
 
 <section data-dfn-for="SerialOptions" data-link-for="SerialOptions">
@@ -382,122 +377,132 @@ enum ParityType {
 <section>
 ## Serial port source abstract operations
 
-## <dfn>SerialPortSourcePullAlgorithm</dfn>(<var>port</var>, <var>controller</var>)
+## <dfn>SerialPortSourcePullAlgorithm</dfn>(|port:SerialPort|, |controller:ReadableStreamDefaultController|)
 
-1. Let <var>promise</var> be
-   <a data-cite="webidl#a-new-promise">a new promise</a>.
-1. <a data-cite="webidl#resolve">Resolve</a> <var>promise</var>.
-1. Return <var>promise</var> and run the following steps <a data-cite="html#in-parallel">in parallel</a>:
-    1. Let <var>desiredSize</var> be <var>controller</var>.
-       <a data-cite="streams#rs-default-controller-desired-size">`desiredSize`</a>.
-    1. Let <var>buffer</var> be a newly created
-       <a data-cite="webidl#idl-ArrayBuffer">`ArrayBuffer`</a> of
-       <var>desiredSize</var> bytes.
-    1. Invoke the operating system to read up to <var>desiredSize</var> bytes
-       from <var>port</var> into <var>buffer</var>.
-    1. If no errors were encountered run the following steps:
-       1. Let <var>bytesRead</var> be the number of bytes written to
-          <var>buffer</var>.
-       1. Let <var>chunk</var> be a newly created
-          <a data-cite="webidl#idl-Uint8Array">`Uint8Array`</a> over the slice of
-          <var>buffer</var> from `0` to <var>bytesRead</var>.
-       1. Invoke <var>controller</var>.
-          <a data-cite="streams#rs-default-controller-enqueue">`enqueue()`</a>
-          with <var>chunk</var>.
-    1. If a buffer overrun condition was encountered, invoke
-       <var>controller</var>.
-       <a data-cite="streams#rs-default-controller-error">`error()`</a> with a
-       <dfn>`BufferOverrunError`</dfn>.
-    1. If a break condition was encountered, invoke <var>controller</var>.
-       <a data-cite="streams#rs-default-controller-error">`error()`</a> with a
-       <dfn>`BreakError`</dfn>.
-    1. If a framing error was encountered, invoke <var>controller</var>.
-       <a data-cite="streams#rs-default-controller-error">`error()`</a> with a
-       <dfn>`FramingError`</dfn>.
-    1. If a parity error was encountered, invoke <var>controller</var>.
-       <a data-cite="streams#rs-default-controller-error">`error()`</a> with a
-       <dfn>`ParityError`</dfn>.
-    1. If an operating system error was encountered, invoke
-       <var>controller</var>.
-       <a data-cite="streams#rs-default-controller-error">`error()`</a> with an
-       <a data-cite="webidl#unknownerror">`UnknownError`</a>.
-    1. If <var>port</var> was disconnected, invoke <var>controller</var>.
-       <a data-cite="streams#rs-default-controller-error">`error()`</a> with a
-       <a data-cite="webidl#networkerror">`NetworkError`</a>.
+<ol>
+  <li>Let |promise:Promise| be [=a new promise=].</li>
+  <li>[=Resolve=] |promise|.</li>
+  <li>
+    Return |promise| and run the following steps [=in parallel=]:
+    <ol>
+      <li>
+        Let |desiredSize| be |controller|.
+        <a data-cite="streams#rs-default-controller-desired-size">`desiredSize`</a>.
+      </li>
+      <li>
+        Let |buffer| be a newly created {{ArrayBuffer}} of |desiredSize| bytes.
+      </li>
+      <li>
+        Invoke the operating system to read up to |desiredSize| bytes from
+        |port| into |buffer|.
+      </li>
+      <li>
+        If no errors were encountered run the following steps:
+        <ol>
+          <li>Let |bytesRead| be the number of bytes written to |buffer|.</li>
+          <li>
+            Let |chunk| be a newly created {{Uint8Array}} over the slice of
+            |buffer| from `0` to |bytesRead|.
+          <li>
+            Invoke |controller|.
+            <a data-cite="streams#rs-default-controller-enqueue">`enqueue()`</a>
+            with |chunk|.
+          </li>
+        </ol>
+      <li>
+        If a buffer overrun condition was encountered, invoke
+        |controller|.
+        <a data-cite="streams#rs-default-controller-error">`error()`</a> with a
+        <dfn>`BufferOverrunError`</dfn>.
+      </li>
+      <li>
+        If a break condition was encountered, invoke |controller|.
+        <a data-cite="streams#rs-default-controller-error">`error()`</a> with a
+        <dfn>`BreakError`</dfn>.
+      </li>
+      <li>
+        If a framing error was encountered, invoke |controller|.
+        <a data-cite="streams#rs-default-controller-error">`error()`</a> with a
+        <dfn>`FramingError`</dfn>.
+      </li>
+      <li>
+        If a parity error was encountered, invoke |controller|.
+        <a data-cite="streams#rs-default-controller-error">`error()`</a> with a
+        <dfn>`ParityError`</dfn>.
+      </li>
+      <li>
+        If an operating system error was encountered, invoke
+        |controller|.
+        <a data-cite="streams#rs-default-controller-error">`error()`</a> with an
+        {{UnknownError}}.
+      </li>
+      <li>
+        If |port| was disconnected, invoke |controller|.
+        <a data-cite="streams#rs-default-controller-error">`error()`</a> with a
+        {{NetworkError}}.
+      </li>
+    </ol>
+  </li>
+</ol>
 
 <p class="note">
-The <a data-cite="webidl#promise">`Promise`</a> returned by this algorithm is
-immediately resolved so that it does not block canceling the stream. [[STREAMS]]
-specifies that this algorithm will not be invoked again until a chunk is
-enqueued.
+The {{Promise}} returned by this algorithm is immediately resolved so that it
+does not block canceling the stream. [[STREAMS]] specifies that this algorithm
+will not be invoked again until a chunk is enqueued.
 </p>
 
-## <dfn>SerialPortSourceCancelAlgorithm</dfn>(port)
+## <dfn>SerialPortSourceCancelAlgorithm</dfn>(|port:SerialPort|)
 
-1. Let <var>promise</var> be a newly created
-   <a data-cite="webidl#promise">`Promise`</a>.
-1. <a data-cite="html#in-parallel">In parallel</a>, invoke the operating system
-   to discard the contents of all software and hardware receive buffers for
-   <var>port</var> and <a data-cite="webidl#resolve">resolve</a>
-   <var>promise</var>.
-1. Return <var>promise</var>.
+1. Let |promise| be [=a new promise=].
+1. [=In parallel=], invoke the operating system to discard the contents of all
+   software and hardware receive buffers for |port| and [=resolve=] |promise|.
+1. Return |promise|.
 </section>
 
 <section>
 ## Serial port sink abstract operations
 
-## <dfn>SerialPortSinkWriteAlgorithm</dfn>(<var>port</var>, <var>chunk</var>)
+## <dfn>SerialPortSinkWriteAlgorithm</dfn>(|port:SerialPort|, |chunk:Uint8Array|)
 
-1. Let <var>promise</var> be a newly created
-   <a data-cite="webidl#promise">`Promise`</a>.
-1. <a data-cite="html#in-parallel">In parallel</a>, run the following steps:
-   1. Invoke the operating system to write <var>chunk</var> to <var>port</var>.
-   1. If the chunk was successfully written
-      <a data-cite="webidl#resolve">resolve</a> <var>promise</var>.
-   1. If an operating system error was encountered,
-      <a data-cite="webidl#reject">reject</a> <var>promise</var>
-      with an <a data-cite="webidl#unknownerror">`UnknownError`</a>.
-   1. If <var>port</var> was disconnected,
-      <a data-cite="webidl#reject">reject</a> <var>promise</var> with a
-      <a data-cite="webidl#networkerror">`NetworkError`</a>.
-1. Return <var>promise</var>.
+1. Let |promise:Promise| be [=a new promise=].
+1. [=In parallel=], run the following steps:
+<ol>
+   1. Invoke the operating system to write |chunk| to |port|.
+   1. If the chunk was successfully written [=resolve=] |promise|.
+   1. If an operating system error was encountered, [=reject=] |promise| with an
+      {{UnknownError}}.
+   1. If |port| was disconnected, [=reject=] |promise| with a {{NetworkError}}.
+</ol>
+1. Return |promise|.
 
 <p class="note">
 [[STREAMS]] specifies that {{SerialPortSinkWriteAlgorithm}} will only be invoked
-after the <a data-cite="webidl#promise">`Promise`</a> returned by a previous
-invocation of this algorithm has resolved. This prevents implementations from
-coalescing multiple chunks waiting in the
-<a data-cite="streams#ws-class">`WritableStream`'s</a> internal queue into a
-single request to the operating system.
+after the {{Promise}} returned by a previous invocation of this algorithm has
+resolved. This prevents implementations from coalescing multiple chunks waiting
+in the {{WritableStream}}'s internal queue into a single request to the
+operating system.
 </p>
 
-## <dfn>SerialPortSinkAbortAlgorithm</dfn>(<var>port</var>, <var>reason</var>)
+## <dfn>SerialPortSinkAbortAlgorithm</dfn>(|port:SerialPort|)
 
-1. Let <var>promise</var> be
-   <a data-cite="webidl#a-new-promise">a new promise</a>.
-1. <a data-cite="html#in-parallel">In parallel</a>, invoke the operating system
-   to discard the contents of all software and hardware transmit buffers for
-   <var>port</var> and <a data-cite="webidl#resolve">resolve</a>
-   <var>promise</var>.
-1. Return <var>promise</var>.
+1. Let |promise| be [=a new promise=].
+1. [=In parallel=], invoke the operating system to discard the contents of all
+   software and hardware transmit buffers for |port| and [=resolve=] |promise|.
+1. Return |promise|.
 
 <p class="note">
 [[STREAMS]] specifies that {{SerialPortSinkAbortAlgorithm}} will only be invoked
-after the <a data-cite="webidl#idl-promise">`Promise`</a> returned by a previous
-invokation of {{SerialPortSinkWriteAlgorithm}} (if any) has resolved. This
-blocks abort on completion of the most recent write operation. This could be
-fixed by passing an <a data-cite="dom#abortsignal">`AbortSignal`</a>
-to {{SerialPortSinkWriteAlgorithm}}.
+after the {{Promise}} returned by a previous invocation of
+{{SerialPortSinkWriteAlgorithm}} (if any) has resolved. This blocks abort on
+completion of the most recent write operation. This could be fixed by passing an
+{{AbortSignal}} to {{SerialPortSinkWriteAlgorithm}}.
 </p>
 
-## <dfn>SerialPortSinkCloseAlgorithm</dfn>(<var>port</var>)
+## <dfn>SerialPortSinkCloseAlgorithm</dfn>(|port:SerialPort|)
 
-1. Let <var>promise</var> be
-   <a data-cite="webidl#a-new-promise">a new promise</a>.
-1. <a data-cite="html#in-parallel">In parallel</a>, invoke the operating system
-   to flush the contents of all software and hardware transmit buffers for
-   <var>port</var> and <a data-cite="webidl#resolve">resolve</a>
-   <var>promise</var>.
+1. Let |promise| be [=a new promise=].
+1. [=In parallel=], invoke the operating system to flush the contents of all
+   software and hardware transmit buffers for |port| and [=resolve=] |promise|.
 </section>
 
 ## Security considerations

--- a/index.html
+++ b/index.html
@@ -375,45 +375,51 @@ enum ParityType {
 
 1. Let <var>promise</var> be a newly created
    <a data-cite="webidl#promise">`Promise`</a>.
-1. <a data-cite="html#in-parallel">In parallel</a>, run the following steps:
-   1. Let <var>desiredSize</var> be <var>controller</var>.
-      <a data-cite="streams#rs-default-controller-desired-size">`desiredSize`</a>.
-   1. Let <var>buffer</var> be a newly created
-      <a data-cite="webidl#idl-ArrayBuffer">`ArrayBuffer`</a> of
-      <var>desiredSize</var> bytes.
-   1. Invoke the operating system to read up to <var>desiredSize</var> bytes
-      from <var>port</var> into <var>buffer</var>.
-   1. If no errors were encountered run the following steps:
-      1. Let <var>bytesRead</var> be the number of bytes written to
-         <var>buffer</var>.
-      1. Let <var>chunk</var> be a newly created
-         <a data-cite="webidl#idl-Uint8Array">`Uint8Array`</a> over the slice of
-         <var>buffer</var> from `0` to <var>bytesRead</var>.
-      1. Invoke <var>controller</var>.
-         <a data-cite="streams#rs-default-controller-enqueue">`enqueue()`</a>
-         with <var>chunk</var>.
-   1. If a buffer overrun condition was encountered, invoke
-      <var>controller</var>.
-      <a data-cite="streams#rs-default-controller-error">`error()`</a> with a
-      <dfn>`BufferOverrunError`</dfn>.
-   1. If a break condition was encountered, invoke <var>controller</var>.
-      <a data-cite="streams#rs-default-controller-error">`error()`</a> with a
-      <dfn>`BreakError`</dfn>.
-   1. If a framing error was encountered, invoke <var>controller</var>.
-      <a data-cite="streams#rs-default-controller-error">`error()`</a> with a
-      <dfn>`FramingError`</dfn>.
-   1. If a parity error was encountered, invoke <var>controller</var>.
-      <a data-cite="streams#rs-default-controller-error">`error()`</a> with a
-      <dfn>`ParityError`</dfn>.
-   1. If an operating system error was encountered, invoke
-      <var>controller</var>.
-      <a data-cite="streams#rs-default-controller-error">`error()`</a> with an
-      <a data-cite="webidl#unknownerror">`UnknownError`</a>.
-   1. If <var>port</var> was disconnected, invoke <var>controller</var>.
-      <a data-cite="streams#rs-default-controller-error">`error()`</a> with a
-      <a data-cite="webidl#networkerror">`NetworkError`</a>.
-   1. Resolve <var>promise</var>.
-1. Return <var>promise</var>.
+1. Resolve <var>promise</var>.
+1. Return <var>promise</var> and run the following steps <a data-cite="html#in-parallel">in parallel</a>:
+    1. Let <var>desiredSize</var> be <var>controller</var>.
+       <a data-cite="streams#rs-default-controller-desired-size">`desiredSize`</a>.
+    1. Let <var>buffer</var> be a newly created
+       <a data-cite="webidl#idl-ArrayBuffer">`ArrayBuffer`</a> of
+       <var>desiredSize</var> bytes.
+    1. Invoke the operating system to read up to <var>desiredSize</var> bytes
+       from <var>port</var> into <var>buffer</var>.
+    1. If no errors were encountered run the following steps:
+       1. Let <var>bytesRead</var> be the number of bytes written to
+          <var>buffer</var>.
+       1. Let <var>chunk</var> be a newly created
+          <a data-cite="webidl#idl-Uint8Array">`Uint8Array`</a> over the slice of
+          <var>buffer</var> from `0` to <var>bytesRead</var>.
+       1. Invoke <var>controller</var>.
+          <a data-cite="streams#rs-default-controller-enqueue">`enqueue()`</a>
+          with <var>chunk</var>.
+    1. If a buffer overrun condition was encountered, invoke
+       <var>controller</var>.
+       <a data-cite="streams#rs-default-controller-error">`error()`</a> with a
+       <dfn>`BufferOverrunError`</dfn>.
+    1. If a break condition was encountered, invoke <var>controller</var>.
+       <a data-cite="streams#rs-default-controller-error">`error()`</a> with a
+       <dfn>`BreakError`</dfn>.
+    1. If a framing error was encountered, invoke <var>controller</var>.
+       <a data-cite="streams#rs-default-controller-error">`error()`</a> with a
+       <dfn>`FramingError`</dfn>.
+    1. If a parity error was encountered, invoke <var>controller</var>.
+       <a data-cite="streams#rs-default-controller-error">`error()`</a> with a
+       <dfn>`ParityError`</dfn>.
+    1. If an operating system error was encountered, invoke
+       <var>controller</var>.
+       <a data-cite="streams#rs-default-controller-error">`error()`</a> with an
+       <a data-cite="webidl#unknownerror">`UnknownError`</a>.
+    1. If <var>port</var> was disconnected, invoke <var>controller</var>.
+       <a data-cite="streams#rs-default-controller-error">`error()`</a> with a
+       <a data-cite="webidl#networkerror">`NetworkError`</a>.
+
+<p class="note">
+The <a data-cite="webidl#promise">`Promise`</a> returned by this algorithm is
+immediately resolved so that it does not block canceling the stream. [[STREAMS]]
+specifies that this algorithm will not be invoked again until a chunk is
+enqueued.
+</p>
 
 ## <dfn>SerialPortSourceCancelAlgorithm</dfn>(port)
 
@@ -423,14 +429,6 @@ enum ParityType {
    to discard the contents of all software and hardware receive buffers for
    <var>port</var> and resolve <var>promise</var>.
 1. Return <var>promise</var>.
-
-<p class="note">
-[[STREAMS]] specifies that {{SerialPortSourceCancelAlgorithm}} will only be
-invoked after the <a data-cite="webidl#promise">`Promise`</a> returned by a
-previous invocation of {{SerialPortSourcePullAlgorithm}} (if any) has resolved.
-This blocks cancelation of the stream until the operating system has completed
-a read operation.
-</p>
 </section>
 
 <section>
@@ -454,7 +452,8 @@ a read operation.
 after the <a data-cite="webidl#promise">`Promise`</a> returned by a previous
 invocation of this algorithm has resolved. This prevents implementations from
 coalescing multiple chunks waiting in the
-<a data-cite="streams#ws-class">`WritableStream`'s</a> internal queue.
+<a data-cite="streams#ws-class">`WritableStream`'s</a> internal queue into a
+single request to the operating system.
 </p>
 
 ## <dfn>SerialPortSinkAbortAlgorithm</dfn>(<var>port</var>, <var>reason</var>)
@@ -470,8 +469,9 @@ coalescing multiple chunks waiting in the
 [[STREAMS]] specifies that {{SerialPortSinkAbortAlgorithm}} will only be invoked
 after the <a data-cite="webidl#promise">`Promise`</a> returned by a previous
 invokation of {{SerialPortSinkWriteAlgorithm}} (if any) has resolved. This
-prevents users of this specification from also discarding the contents of the
-<a data-cite="streams#ws-class">`WritableStream`'s</a> internal queue.
+blocks abort on completion of the most recent write operation. This could be
+fixed by passing an <a data-cite="dom#interface-AbortSignal">`AbortSignal`</a>
+to {{SerialPortSinkWriteAlgorithm}}.
 </p>
 
 ## <dfn>SerialPortSinkCloseAlgorithm</dfn>(<var>port</var>)

--- a/respecConfig.js
+++ b/respecConfig.js
@@ -20,4 +20,5 @@ var respecConfig = {
   // URI of the public WG page
   wgURI: "https://www.w3.org/community/wicg/",
   github: "https://github.com/wicg/serial",
+  xref: ["dom", "html", "streams", "webidl"],
 };

--- a/respecConfig.js
+++ b/respecConfig.js
@@ -20,5 +20,5 @@ var respecConfig = {
   // URI of the public WG page
   wgURI: "https://www.w3.org/community/wicg/",
   github: "https://github.com/wicg/serial",
-  xref: ["dom", "html", "streams", "webidl"],
+  xref: ["STREAMS", "DOM", "WebIDL", "HTML"]
 };

--- a/security-privacy-questionnaire.md
+++ b/security-privacy-questionnaire.md
@@ -1,0 +1,95 @@
+# Security and Privacy Questionnaire
+
+Questions pulled from the [Self-Review Questionaire on Security and Privacy](https://www.w3.org/TR/security-privacy-questionnaire/).
+
+## What information might this feature expose to Web sites or other parties, and for what purposes is that exposure necessary?
+
+By allowing a site to communicate with a peripheral device it is exposed to any information that the device makes available through that connection. For example, a device may provide a command for checking the currently installed firmware version or reading the serial number, which must be assumed to be unique. The device may also have access to information about the user's environment. For example, it may include a temperature sensor.
+
+No effort is made by this specification to limit the type of data that can be read from the device once the user has granted a site permission to communicate with it. The reason for this is that serial device communication is a bidirectional byte stream that is entirely opaque to the user agent.
+
+The trade-off being made is that users benefit from being able to perform a task using a web application rather than a native application. Web applications do not require installation and so are ideal for tasks that are performed infrequently. They are also sandboxed away from both the underlying platform and each other. Access to a powerful capability such as communication with a connected serial device can be placed behind a permission request that only grants a site access to a particular device, rather than the ability to run arbitrary native code on the user's system and access to all capabilities granted by default on the native platform.
+
+## Is this specification exposing the minimum amount of information necessary to power the feature?
+
+The specification minimizes the information exposed to a site by gating all access to devices and their properties behind a permission request that requires the user to select a single device. This mitigates "drive by" attacks which could attempt to fingerprint a user by detecting the types of devices they have connected.
+
+As explained above, however, once the user grants a site permission to communicate with a device it becomes impractical to limit the types of device properties that it could observe.
+
+## How does this specification deal with personal information or personally-identifiable information or information derived thereof?
+
+The capability granted by this specification does not directly deal with personal inforamtion or personally-identifiable information, however a particular device may contain such information and allowing a site to communicate with such a device could reveal this information. For example, a developer of a medical device could use this API in order to read and upload stored medical data to the cloud for analysis by the patient's doctor.
+
+The permission model requires the user to concent to access by the site to the device.
+
+## How does this specification deal with sensitive information?
+
+The answer to this is the same as the question above.
+
+To protect the potentially sensitive data that can be read from the device the specification requires that the API be accessible only from secure contexts. This does not prevent malicious use of the API but ensures,
+
+* that the user's decision to grant the site permission to access a device is meaningful by validating that the origin displayed is accurate,
+* that the site content has not been tampered with by an active network attacker, and
+* that any data sent back to the site is not visibile to a passive network attacker.
+
+## Does this specification introduce new state for an origin that persists across browsing sessions?
+
+This specification introduces a new permission which associates a set of devices with an origin. For frequently visited sites experience with other APIs such as Web Bluetooth shows that users prefer not to be asked to grant the same permission for every session. Implementations may therefore support persisting the user's choice between sessions. This permission is state that persists across browsing sessions. Implementations should clear this state when the user indicates they would like to clear other site data such as cookies and local storage. Implementations may also make remembering the user's choices optional, time limited or expire after a site has not been visited for some time.
+
+In addition it must be assumed that the device may support configuration and data storage that persists between sessions. This state is stored by the device itself and cannot be cleared by the user agent. The permission model is designed to treat access to a device the same way as access to a local file, since both represent state which is outside of the user agent's control.
+
+## What information from the underlying platform, e.g. configuration data, is exposed by this specification to an origin?
+
+No information from the underlying platform is exposed by this specification without user interaction. Once a user has chosen a device to grant a site permission to access that site has access to any information available by communicating with that device as well as basic properties of the device such as a device name, model ID or serial number. The specification does not attempt to obfuscate these IDs because it is assumed that the data is also available by directly communiating with the device in a way that is opaque to the user agent.
+
+Data available from a device is consistent across origins, assuming that the user has granted multiple origins permission to access the same device.
+
+## Does this specification allow an origin access to sensors on a user’s device
+
+A serial device may be a sensor connected to or built into the user's device.
+
+## What data does this specification expose to an origin? Please also document what data is identical to data exposed by other features, in the same or different contexts.
+
+The specification exposes information from the underlying platform as described above.
+
+## Does this specification enable new script execution/loading mechanisms?
+
+No.
+
+## Does this specification allow an origin to access other devices?
+
+This specification allows an origin to communicate directly with serial devices. The risks and mitigations are addressed elsewhere in this questionnaire.
+
+## Does this specification allow an origin some measure of control over a user agent’s native UI?
+
+No. The `requestDevice()` method, which can cause the user agent to display native UI, requires a user gesture in order to mitigate abuse.
+
+## What temporary identifiers might this this specification create or expose to the web?
+
+This specification does not create temporary identifiers.
+
+## How does this specification distinguish between behavior in first-party and third-party contexts?
+
+This specification leverages [Feature Policy](https://w3c.github.io/webappsec-feature-policy/) to control access to this feature in third-party contexts. The default policy is `['self']` which restricts the feature to only first-party contexts. If a third-party context is trusted by the first-party context it can be explicitly granted access to the feature.
+
+Access to this feature by third-party contexts is useful because it allows functionality to be composed between sites. For example, a site cataloging 3D models could embed a third-party `<iframe>` element from a 3D printer manufacturer that supports sending the model to the printer using this API. Since this third-party context is trusted to perform this function by the first-party context it would be explicitly allowed to use the feature using the `allow="serial"` attribute. Other third-party contexts on the page, such as advertisments, would not be allowed to use the feature.
+
+## How does this specification work in the context of a user agent’s Private Browsing or "incognito" mode?
+
+Implementations of this specification are expected to implement separate storage for device permissions between the "normal" and "incognito" modes. This mitigates passive leakage of information between sessions. Permissions granted during a private browsing session are expected to be cleared at the end of that session.
+
+As discussed above, communication with a device grants a site the ability to read potentially identifying information from the device. Implementations should frame a site's permission request in a way that brings the user's attention to the powerful nature of this request using words like "access" or "control". In an incognito context this message may be strengthened to highlight the potential for this action to "unmask" a user in the same way that entering personal credentials or uploading a file would.
+
+Since the default state before any permissions are granted is that the site has access to no devices it is not possible to detect an incognito session using this API.
+
+## Does this specification have a "Security Considerations" and "Privacy Considerations" section?
+
+Yes, as of writing the [Security considerations](https://github.com/WICG/serial/blob/gh-pages/EXPLAINER.md#security-considerations) and [Privacy considerations](https://github.com/WICG/serial/blob/gh-pages/EXPLAINER.md#privacy-considerations) sections in the explainer are the most complete.
+
+## Does this specification allow downgrading default security characteristics?
+
+No.
+
+## What should this questionnaire have asked?
+
+When considering adding a feature to the web platform it is useful to consider how other platforms control access to the same feature. In this case desktop platforms do not require any user consent before granting an application access to a serial device.

--- a/tidyconfig.txt
+++ b/tidyconfig.txt
@@ -2,3 +2,4 @@ char-encoding: utf8
 indent: yes
 wrap: 80
 tidy-mark: no
+newline: LF


### PR DESCRIPTION
This PR adds missing definitions for `connect` and `disconnect` serial connection events. Note that it doesn't include a check for ports that have been granted access yet. I figured out it was OK to start there and iterate with the definition of `getPorts()` in an upcoming PR.

@reillyeon WDYT?