### PR TITLE
Mark optional SerialOutputSignals

### DIFF
--- a/index.html
+++ b/index.html
@@ -129,7 +129,7 @@ for use.
     SerialPortInfo getInfo();
 
     Promise&lt;void> open(SerialOptions options);
-    Promise&lt;void> setSignals(SerialOutputSignals signals);
+    Promise&lt;void> setSignals(optional SerialOutputSignals signals = {});
     Promise&lt;SerialInputSignals> getSignals();
     void close();
   };


### PR DESCRIPTION
This PR fixes the WebIDL issue below by marking  optional `SerialOutputSignals` in `SerialPort.setSignals`.


```
Validation error at line 3, inside `interface SerialPort -> operation setSignals -> argument signals`:
void> setSignals(SerialOutputSignals signals);
                                     ^ Dictionary argument must be optional if it has no required fields
```

I'm not sure there's a way to say "I want this dictionary to be required with at least one member" sadly. If not, let's try marking it optional, and say in the spec that we should throw if not least one member if present. WDYT?